### PR TITLE
Implemented cmd from core-devtools

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/TouchBistro/tb/util"
+	"github.com/spf13/cobra"
+)
+
+// wack but I'm just copying core-devtools for now
+// should probably rename this to something less wack later
+var cmdCmd = &cobra.Command{
+	Use:   "cmd <service-name> <command> [additional-commands...]",
+	Short: "executes a command in a service container",
+	Args:  cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		files, err := util.ComposeFiles()
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		service := args[0]
+		cmds := strings.Join(args[1:], " ")
+		cmdStr := fmt.Sprintf("%s exec %s %s", files, service, cmds)
+
+		execCmd := exec.Command("docker-compose", strings.Fields(cmdStr)...)
+		execCmd.Stdout = os.Stdout
+		execCmd.Stderr = os.Stderr
+		execCmd.Stdin = os.Stdin
+
+		err = execCmd.Run()
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(cmdCmd)
+}

--- a/util/compose_files.go
+++ b/util/compose_files.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func ComposeFiles() (string, error) {
+	matches, err := filepath.Glob("./docker-compose.*.yml")
+
+	if err != nil {
+		return "", err
+	}
+
+	if len(matches) == 0 {
+		return "", nil
+	}
+
+	str := "-f " + strings.Join(matches, " -f ")
+
+	return str, nil
+}


### PR DESCRIPTION
* Added `cmd` command from `core-devtools`.
* Implemented `bin/compose_files` since it was required by `cmd`.
  * Created it as a util function instead of a command as this is something that is used by other commands and not likely to be used by the user.