### PR TITLE
chore: add INFRASTRUCTURE_AUTH_SERVICE_{JWKS_URI|ISSUER} to core

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -173,7 +173,11 @@ x-venue-core-service-boilerplate:
     AWS_S3_CORE_FILE_URL_TEMPLATE: http://localstack:4572/%%s3Bucket%%/%%s3ObjectKey%%
     AWS_S3_ENDPOINT: http://localstack:4572
     LOCALSTACK_SQS_URL: http://localstack:4576
+    # Note: Remove USE_INSECURE_IMPERSONATE after https://github.com/TouchBistro/venue-core-service/pull/239 is merged.
+    # Keeping for backwards compatibility.
     USE_INSECURE_IMPERSONATE: insecure
+    INFRASTRUCTURE_AUTH_SERVICE_JWKS_URI: http://${INFRASTRUCTURE_AUTH_SERVICE_NAME}:8080/jwks
+    INFRASTRUCTURE_AUTH_SERVICE_ISSUER: urn:touchbistro:oauth:iss:services:local
     TASK_AWS_SQS_CONFIG_JSON: >
       {"core.task.data.migration":{"queueURL":"http://localstack:4576/queue/coreTest","messageThrottle":1,"visibilityTimeout":10,"waitTimeSeconds":5,"sleepTimeSeconds":5}}
   ports:


### PR DESCRIPTION
Backwards compatible & non-breaking.