### PR TITLE
Caveman ios logs

### DIFF
--- a/cmd/ios/ios.go
+++ b/cmd/ios/ios.go
@@ -11,6 +11,7 @@ import (
 // Flags available for multiple commands
 var (
 	iosVersion string
+	deviceName string
 )
 
 var iosCmd = &cobra.Command{
@@ -30,10 +31,6 @@ var iosCmd = &cobra.Command{
 			fatal.ExitErr(err, "Failed to find available iOS simulators")
 		}
 	},
-}
-
-func init() {
-	iosCmd.PersistentFlags().StringVarP(&iosVersion, "ios-version", "i", "13.1", "The iOS version to use")
 }
 
 func IOS() *cobra.Command {

--- a/cmd/ios/logs.go
+++ b/cmd/ios/logs.go
@@ -3,10 +3,10 @@ package ios
 import (
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/TouchBistro/tb/fatal"
 	"github.com/TouchBistro/tb/simulator"
-	"github.com/TouchBistro/tb/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -16,13 +16,19 @@ var (
 )
 
 var logsCmd = &cobra.Command{
-	Use:   "logs <device-name>",
+	Use:   "logs",
 	Short: "Displays logs from the given simulator",
-	Args:  cobra.ExactArgs(1),
+	Long: `Displays logs from the given simulator.
+	
+Examples:
+- displays the last 10 logs in the default iOS simulator
+	tb logs
+
+- displays the last 20 logs in an iOS 12.4 iPad Air 2 simulator
+	tb logs --number 20 --ios-version 12.4 --device iPad Air 2`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Debugln("☐ Finding device UDID")
 
-		deviceName := args[0]
 		deviceUDID, err := simulator.GetDeviceUDID("iOS "+iosVersion, deviceName)
 		if err != nil {
 			fatal.ExitErr(err, "☒ Failed to get device UUID.\nRun \"xcrun simctl list devices\" to list available simulators.")
@@ -31,7 +37,13 @@ var logsCmd = &cobra.Command{
 		log.Debugf("☑ Found device UDID: %s\n", deviceUDID)
 
 		logsPath := fmt.Sprintf("%s/Library/Logs/CoreSimulator/%s/system.log", os.Getenv("HOME"), deviceUDID)
-		err = util.Exec("tail", "tail", "-f", "-n", numberOfLines, logsPath)
+		log.Infof("Attaching to logs for simulator %s\n\n", deviceName)
+
+		execCmd := exec.Command("tail", "-f", "-n", numberOfLines, logsPath)
+		execCmd.Stdout = os.Stdout
+		execCmd.Stderr = os.Stderr
+
+		err = execCmd.Run()
 		if err != nil {
 			fatal.ExitErrf(err, "Failed to get logs for simulator %s with iOS version %s", deviceName, iosVersion)
 		}
@@ -40,5 +52,7 @@ var logsCmd = &cobra.Command{
 
 func init() {
 	iosCmd.AddCommand(logsCmd)
-	runCmd.Flags().StringVarP(&numberOfLines, "number", "n", "10", "The number of lines to display")
+	logsCmd.Flags().StringVarP(&iosVersion, "ios-version", "i", "13.1", "The iOS version to use")
+	logsCmd.Flags().StringVarP(&deviceName, "device", "d", "iPad Air (3rd generation)", "The name of the device to use")
+	logsCmd.Flags().StringVarP(&numberOfLines, "number", "n", "10", "The number of lines to display")
 }

--- a/cmd/ios/run.go
+++ b/cmd/ios/run.go
@@ -18,10 +18,9 @@ import (
 )
 
 var (
-	deviceName string
-	dataPath   string
-	appName    string
-	branch     string
+	dataPath string
+	appName  string
+	branch   string
 )
 
 var runCmd = &cobra.Command{
@@ -210,6 +209,7 @@ Examples:
 
 func init() {
 	iosCmd.AddCommand(runCmd)
+	runCmd.Flags().StringVarP(&iosVersion, "ios-version", "i", "13.1", "The iOS version to use")
 	runCmd.Flags().StringVarP(&deviceName, "device", "d", "iPad Air (3rd generation)", "The name of the device to use")
 	runCmd.Flags().StringVarP(&appName, "app", "a", "TouchBistro", "The name of the application to run, eg TouchBistro")
 	runCmd.Flags().StringVarP(&branch, "branch", "b", "master", "The name of the git branch associated build to pull down and run")


### PR DESCRIPTION
Basic implementation for `tb ios logs` to view simulator logs. Currently just `tail -f` the log file, but we can make it more robust in the future if needed