### PR TITLE
Add IAS to online-ordering playlist

### DIFF
--- a/static/playlists.yml
+++ b/static/playlists.yml
@@ -58,6 +58,7 @@ online-ordering:
     - singleapp-database
     - ordering-engine-service
     - ordering-online-frontend
+    - infrastructure-auth-service
 partners:
   services:
     - postgres


### PR DESCRIPTION
Add IAS to online-ordering playlist - This is a dependancy running locally now.