### PR TITLE
update: remove logger config from venue-core-service in /static

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -52,6 +52,7 @@ x-mysqlconnect: &mysql-connect
   DB_DISABLE_SSL: "true"
 
 x-nodeservice: &node-service
+  <<: *json-logger-config
   HTTP_PORT: 8080
 
 x-command-serve: &command-serve
@@ -199,6 +200,7 @@ x-legacy-bridge-manage-service-boilerplate:
   environment:
     <<: *mssql-connect
     DB_NAME: cloud_db
+    <<: *json-logger-config
   ports:
     - "8999:8080"
   depends_on:


### PR DESCRIPTION
# Changes

- removed logger config from /static. We will configure it in .env.example instead.