### PR TITLE
Revert Update/remove logger config

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -181,6 +181,84 @@ x-venue-core-service-boilerplate: &venue-core-service-boilerplate
     TOUCHBISTRO_LEGACY_BRIDGE_CLOUD_BASE_URL: http://${LEGACY_BRIDGE_CLOUD_SERVICE_NAME}:8080
     TASK_AWS_SQS_CONFIG_JSON: >
       {"core.task.data.migration":{"queueURL":"http://localstack:4576/queue/coreTest","messageThrottle":1,"visibilityTimeout":10,"waitTimeSeconds":5,"sleepTimeSeconds":5}}
+    LOGGER_CONFIG_JSON: >
+      {
+        "transports": {
+          "devConsole": {
+            "provider": "winston.transports.Console",
+            "config": {
+              "colorize": true,
+              "timestamp": true,
+              "json": false
+            }
+          },
+          "graphqlLegacy": {
+            "provider": "winston.transports.File",
+            "config": {
+              "filename": "./logs/request_graphql_legacy.log",
+              "timestamp": true,
+              "json": true
+            }
+          },
+          "graphqlUp": {
+            "provider": "winston.transports.File",
+            "config": {
+              "filename": "./logs/request_graphql_up.log",
+              "timestamp": true,
+              "json": true
+            }
+          },
+          "errorLog": {
+            "provider": "winston.transports.File",
+            "config": {
+              "filename": "./logs/error_log.log",
+              "timestamp": true,
+              "json": true
+            }
+          }
+        },
+        "env": {
+          "development": {
+            "rules": [
+              {
+                "pattern": "*",
+                "binding": {
+                  "transport": ["devConsole"],
+                  "level": "info"
+                }
+              },
+              {
+                "pattern": "core.backend.request.log.graphql.legacy.*",
+                "binding": {
+                  "transport": ["graphqlLegacy"],
+                  "level": "debug"
+                }
+              },
+              {
+                "pattern": "core.backend.request.log.graphql.up.*",
+                "binding": {
+                  "transport": ["graphqlUp"],
+                  "level": "debug"
+                }
+              },
+              {
+                "pattern": "core.backend.loggable.error.class.*",
+                "binding": {
+                  "transport": ["errorLog"],
+                  "level": "debug"
+                }
+              },
+              {
+                "pattern": "core.backend.error.not.from.defined.core.error",
+                "binding": {
+                  "transport": ["errorLog"],
+                  "level": "debug"
+                }
+              }
+            ]
+          }
+        }
+      }
   ports:
     - "8081:8080" # Main HTTP port
     - "9901:9229" # 9229, 9330: Node debugger


### PR DESCRIPTION
We had removed logger config from `/static/docker-compose.yml`, however, new tb has a bug that does not read .env.example in ecr image.
Until this is fixed in tb, we would like to revert back the logger config in `docker-compose.yml` so that we can use `rtail`.