### PR TITLE
Remove logger config from docker-compose.yml

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -1167,7 +1167,6 @@ volumes:
   ordering-ooa-service-node_modules:
   ordering-demo-frontend-node_modules:
   ordering-demo-frontend-venue-node_modules:
-  ordering-deliveroo-service-node_modules:
   ordering-gateways-frontend-node_modules:
   ordering-engine-service-node_modules:
   ordering-online-frontend-node_modules:

--- a/static/services.yml
+++ b/static/services.yml
@@ -109,13 +109,6 @@ services:
       image: ${ecr}/mokta
       tag: master
     repo: TouchBistro/mokta
-  ordering-deliveroo-service:
-    preRun: yarn db:prepare
-    remote:
-      enabled: true
-      image: ${ecr}/ordering-deliveroo-service
-      tag: master
-    repo: TouchBistro/ordering-deliveroo-service
   ordering-demo-frontend:
     preRun: yarn db:prepare
     remote:


### PR DESCRIPTION
Logger config should be handled by each service in `.env.example`.