### PR TITLE
fix: legacy-database volume bug

### DIFF
--- a/static/services.yml
+++ b/static/services.yml
@@ -249,6 +249,9 @@ services:
       enabled: true
       image: ${ecr}/legacy-database
       tag: master-db-migrate-with-seeds
+      volumes:
+        - value: legacy-database:/var/opt/mssql/data
+          named: true
   legacy-upload-service:
     dependencies:
       - postgres


### PR DESCRIPTION
`tb@2.3.0` introduced a regression where `legacy-database` migrations and seeds were being run but not persisted. This resulted in e.g. `rolify_roles` (`access_menu` id=15) not being available for local dev.