### PR TITLE
feat: Add linux support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,11 +14,11 @@ builds:
       - -s -w -X github.com/TouchBistro/tb/cmd.version={{.Version}}
     goos:
       - darwin
+      - linux
+    goarch:
+      - amd64
     hooks:
       post: go run build/build.go
-    ignore:
-      - goos: darwin
-        goarch: 386
 
 archives:
   -

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/TouchBistro/goutils/fatal"
@@ -29,7 +28,7 @@ var appCmd = &cobra.Command{
 		// Check if current command is an ios subcommand
 		isIOSCommand := cmd.Parent().Name() == "ios"
 
-		if isIOSCommand && runtime.GOOS != "darwin" {
+		if isIOSCommand && !util.IsMacOS() {
 			fatal.Exit("Error: tb app ios is only supported on macOS")
 		}
 

--- a/cmd/app/desktop/run.go
+++ b/cmd/app/desktop/run.go
@@ -3,13 +3,13 @@ package desktop
 import (
 	"errors"
 	"os"
-	"runtime"
 
 	"github.com/TouchBistro/goutils/command"
 	"github.com/TouchBistro/goutils/fatal"
 	"github.com/TouchBistro/goutils/file"
 	appCmd "github.com/TouchBistro/tb/cmd/app"
 	"github.com/TouchBistro/tb/config"
+	"github.com/TouchBistro/tb/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -72,7 +72,7 @@ Examples:
 		log.Info("☐ Launching app")
 
 		// TODO probably want to figure out a better way to abstract opening an app cross platform
-		if runtime.GOOS == "darwin" {
+		if util.IsMacOS() {
 			err = command.Exec("open", []string{appPath}, "tb-app-desktop-run-open")
 		} else {
 			fatal.Exit("tb app desktop run is not supported on your platform")

--- a/config/config.go
+++ b/config/config.go
@@ -131,7 +131,13 @@ func Init(opts InitOptions) error {
 	// TODO scope if there's a way to pass lazydocker a custom tb specific config
 	// Also consider creating a lazydocker package to abstract this logic so it doesn't seem so ad hoc
 	// Create lazydocker config
-	ldDirPath := filepath.Join(os.Getenv("HOME"), "Library/Application Support/jesseduffield/lazydocker")
+	var ldDirPath string
+	if util.IsMacOS() {
+		ldDirPath = filepath.Join(os.Getenv("HOME"), "Library/Application Support/jesseduffield/lazydocker")
+	} else {
+		ldDirPath = filepath.Join(os.Getenv("HOME"), ".config/jesseduffield/lazydocker")
+	}
+
 	err = os.MkdirAll(ldDirPath, 0766)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create lazydocker config directory %s", ldDirPath)
@@ -144,7 +150,7 @@ gui:
 update:
   dockerRefreshInterval: 2000ms`
 
-	ldConfigPath := filepath.Join(ldDirPath, "lazydocker.yml")
+	ldConfigPath := filepath.Join(ldDirPath, "config.yml")
 	err = ioutil.WriteFile(ldConfigPath, []byte(lazydockerConfig), 0644)
 	if err != nil {
 		return errors.Wrap(err, "failed to create lazydocker config file")

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -72,11 +72,21 @@ var deps = map[string]Dependency{
 	},
 }
 
+func init() {
+	// In the future maybe we could have a way to initialize deps based of the OS. This could allow for setting different install methods.
+	// Using brew is fine for now though
+	if runtime.GOOS == "linux" {
+		// Update brew install script if linux
+		brew := deps[Brew]
+		brew.InstallCmd = []string{"/bin/bash", "-c", "\"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)\""}
+	}
+}
+
 func Resolve(depNames ...string) error {
 	log.Info("☐ checking dependencies")
 
-	if runtime.GOOS != "darwin" {
-		fatal.Exit("tb currently supports Darwin (MacOS) only for installing dependencies. If you want to support other OSes, please make a pull request.\n")
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		fatal.Exit("tb currently supports Darwin (MacOS) and Linux only for installing dependencies. If you want to support other OSes, please make a pull request.\n")
 	}
 
 	for _, depName := range depNames {

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -1,10 +1,9 @@
 package deps
 
 import (
-	"runtime"
-
 	"github.com/TouchBistro/goutils/command"
 	"github.com/TouchBistro/goutils/fatal"
+	"github.com/TouchBistro/tb/util"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -75,7 +74,7 @@ var deps = map[string]Dependency{
 func init() {
 	// In the future maybe we could have a way to initialize deps based of the OS. This could allow for setting different install methods.
 	// Using brew is fine for now though
-	if runtime.GOOS == "linux" {
+	if util.IsLinux() {
 		// Update brew install script if linux
 		brew := deps[Brew]
 		brew.InstallCmd = []string{"/bin/bash", "-c", "\"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)\""}
@@ -85,7 +84,7 @@ func init() {
 func Resolve(depNames ...string) error {
 	log.Info("☐ checking dependencies")
 
-	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+	if !util.IsMacOS() && !util.IsLinux() {
 		fatal.Exit("tb currently supports Darwin (MacOS) and Linux only for installing dependencies. If you want to support other OSes, please make a pull request.\n")
 	}
 

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -31,7 +31,7 @@ const (
 var deps = map[string]Dependency{
 	Brew: {
 		Name:       "brew",
-		InstallCmd: []string{"/usr/bin/ruby", "-e", "\"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\""},
+		InstallCmd: []string{"/bin/bash", "-c", "\"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)\""},
 	},
 	Pgcli: {
 		Name: "pgcli",
@@ -69,16 +69,6 @@ var deps = map[string]Dependency{
 		Name:       "yarn",
 		InstallCmd: []string{"brew", "install", "yarn"},
 	},
-}
-
-func init() {
-	// In the future maybe we could have a way to initialize deps based of the OS. This could allow for setting different install methods.
-	// Using brew is fine for now though
-	if util.IsLinux() {
-		// Update brew install script if linux
-		brew := deps[Brew]
-		brew.InstallCmd = []string{"/bin/bash", "-c", "\"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)\""}
-	}
 }
 
 func Resolve(depNames ...string) error {

--- a/git/github.go
+++ b/git/github.go
@@ -70,8 +70,6 @@ func GetLatestRelease() (string, error) {
 		return "", errors.Wrap(err, "Failed to create GET request to GitHub API")
 	}
 
-	token := fmt.Sprintf("token %s", os.Getenv(tokenVar))
-	req.Header.Add("Authorization", token)
 	// Use v3 API
 	req.Header.Add("Accept", "application/vnd.github.v3+json")
 

--- a/util/util.go
+++ b/util/util.go
@@ -3,10 +3,19 @@ package util
 import (
 	"fmt"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/pkg/errors"
 )
+
+func IsMacOS() bool {
+	return runtime.GOOS == "darwin"
+}
+
+func IsLinux() bool {
+	return runtime.GOOS == "linux"
+}
 
 func Prompt(msg string) bool {
 	// check for yes and assume no on any other input to avoid annoyance


### PR DESCRIPTION
Add support for running `tb` on linux. Closes #268 
Also remove setting `Authorization` header when getting the latest version of `tb` from the GitHub API since the repo is now public.