### PR TITLE
chore: Minor documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ To toggle debug mode set the `debug` property to `true` or `false`. Debug mode w
 ### Toggling experimental mode
 To to enable experimental mode set the `experimental` field to `true`. Experimental mode will give you access to any new features that are still in the process of being tested.
 Please be aware that you may encounter bugs with these features as they have not yet been deemed ready for general use.
+Also, experimental mode is not covered by semver guarantees, so there could be breaking changes at any time.
 
 If you would like to help use test new features, we would appreciate it if you could enable experimental mode and report any issues you encounter.
 

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -185,6 +185,20 @@ dependencies:
   - ${@postgres}
 ```
 
+##### Literal Variables
+
+If you required the literal variable syntax and don't want `tb` to expand it, prefix the variable name with `@env:`. `tb` will strip this prefix and leave the variable expansion syntax.
+
+Ex:
+```yaml
+envPath: ${@env:HOME}/tmp
+```
+
+`tb` will turn this into:
+```yaml
+envPath: ${HOME}/tmp
+```
+
 ## Configuring Playlists
 
 A playlist is a collection of services that can be run with `tb up`.


### PR DESCRIPTION
* Explicitly state that experimental mode is not covered by semver
* Document literal variable syntax in services.yml