### PR TITLE
fix: Find latest iOS version correctly

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -11,7 +11,6 @@ import (
 	"github.com/TouchBistro/tb/app"
 	"github.com/TouchBistro/tb/config"
 	"github.com/TouchBistro/tb/git"
-	"github.com/TouchBistro/tb/simulator"
 	"github.com/TouchBistro/tb/storage"
 	"github.com/TouchBistro/tb/util"
 	"github.com/pkg/errors"
@@ -48,13 +47,6 @@ var appCmd = &cobra.Command{
 		})
 		if err != nil {
 			fatal.ExitErr(err, "Failed to initialize config files")
-		}
-
-		if isIOSCommand {
-			err = simulator.LoadSimulators()
-			if err != nil {
-				fatal.ExitErr(err, "Failed to find available iOS simulators")
-			}
 		}
 	},
 }

--- a/cmd/app/ios/logs.go
+++ b/cmd/app/ios/logs.go
@@ -32,14 +32,28 @@ Examples:
 - displays the last 20 logs in an iOS 12.4 iPad Air 2 simulator
 	tb app logs --number 20 --ios-version 12.4 --device iPad Air 2`,
 	Run: func(cmd *cobra.Command, args []string) {
+		deviceData, err := simulator.ListDevices()
+		if err != nil {
+			fatal.ExitErr(err, "Failed to get list of simulators")
+		}
+
+		deviceList, err := simulator.ParseSimulators(deviceData)
+		if err != nil {
+			fatal.ExitErr(err, "Failed to find available iOS simulators")
+		}
+
 		if logOpts.iosVersion == "" {
-			logOpts.iosVersion = simulator.GetLatestIOSVersion()
+			logOpts.iosVersion, err = deviceList.GetLatestIOSVersion()
+			if err != nil {
+				fatal.ExitErr(err, "failed to get latest iOS version")
+			}
+
 			log.Infof("No iOS version provided, defaulting to version %s\n", logOpts.iosVersion)
 		}
 
 		log.Debugln("☐ Finding device UDID")
 
-		deviceUDID, err := simulator.GetDeviceUDID("iOS "+logOpts.iosVersion, logOpts.deviceName)
+		deviceUDID, err := deviceList.GetDeviceUDID("iOS "+logOpts.iosVersion, logOpts.deviceName)
 		if err != nil {
 			fatal.ExitErr(err, "☒ Failed to get device UUID.\nRun \"xcrun simctl list devices\" to list available simulators.")
 		}

--- a/cmd/app/ios/run.go
+++ b/cmd/app/ios/run.go
@@ -51,13 +51,27 @@ Examples:
 			fatal.ExitErrf(err, "%s is not a valid iOS app\n", appName)
 		}
 
+		deviceData, err := simulator.ListDevices()
+		if err != nil {
+			fatal.ExitErr(err, "Failed to get list of simulators")
+		}
+
+		deviceList, err := simulator.ParseSimulators(deviceData)
+		if err != nil {
+			fatal.ExitErr(err, "Failed to find available iOS simulators")
+		}
+
 		// Override branch if one was provided
 		if runOpts.branch != "" {
 			a.Branch = runOpts.branch
 		}
 
 		if runOpts.iosVersion == "" {
-			runOpts.iosVersion = simulator.GetLatestIOSVersion()
+			runOpts.iosVersion, err = deviceList.GetLatestIOSVersion()
+			if err != nil {
+				fatal.ExitErr(err, "failed to get latest iOS version")
+			}
+
 			log.Infof("No iOS version provided, defaulting to version %s\n", runOpts.iosVersion)
 		}
 
@@ -72,7 +86,7 @@ Examples:
 		appPath := appCmd.DownloadLatestApp(a, downloadDest)
 
 		log.Debugln("☐ Finding device UDID")
-		deviceUDID, err := simulator.GetDeviceUDID("iOS "+runOpts.iosVersion, runOpts.deviceName)
+		deviceUDID, err := deviceList.GetDeviceUDID("iOS "+runOpts.iosVersion, runOpts.deviceName)
 		if err != nil {
 			fatal.ExitErr(err, "☒ Failed to get device UDID.\nRun \"xcrun simctl list devices\" to list available simulators.")
 		}

--- a/simulator/simulator_test.go
+++ b/simulator/simulator_test.go
@@ -1,0 +1,46 @@
+package simulator
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDeviceUDID(t *testing.T) {
+	assert := assert.New(t)
+
+	deviceData, err := ioutil.ReadFile("testdata/devices.json")
+	if err != nil {
+		assert.FailNow("Failed to read devices json file", err)
+	}
+
+	deviceList, err := ParseSimulators(deviceData)
+	if err != nil {
+		assert.FailNow("Failed to parse simulators", err)
+	}
+
+	deviceUDID, err := deviceList.GetDeviceUDID("iOS 13.5", "iPad Pro (9.7-inch)")
+
+	assert.NoError(err)
+	assert.Equal("A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1", deviceUDID)
+}
+
+func TestGetLatestIOSVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	deviceData, err := ioutil.ReadFile("testdata/devices.json")
+	if err != nil {
+		assert.FailNow("Failed to read devices json file", err)
+	}
+
+	deviceList, err := ParseSimulators(deviceData)
+	if err != nil {
+		assert.FailNow("Failed to parse simulators", err)
+	}
+
+	version, err := deviceList.GetLatestIOSVersion()
+
+	assert.NoError(err)
+	assert.Equal("13.5", version)
+}

--- a/simulator/testdata/devices.json
+++ b/simulator/testdata/devices.json
@@ -1,0 +1,187 @@
+{
+  "devices": {
+    "com.apple.CoreSimulator.SimRuntime.tvOS-13-2": [],
+    "com.apple.CoreSimulator.SimRuntime.watchOS-6-0": [],
+    "com.apple.CoreSimulator.SimRuntime.iOS-13-2": [],
+    "com.apple.CoreSimulator.SimRuntime.tvOS-13-3": [],
+    "com.apple.CoreSimulator.SimRuntime.iOS-13-3": [],
+    "com.apple.CoreSimulator.SimRuntime.tvOS-12-4": [],
+    "com.apple.CoreSimulator.SimRuntime.tvOS-13-4": [
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/E20F9E7E-4E18-478A-BD06-170F3289F45B/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/E20F9E7E-4E18-478A-BD06-170F3289F45B",
+        "udid": "E20F9E7E-4E18-478A-BD06-170F3289F45B",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p",
+        "state": "Shutdown",
+        "name": "Apple TV"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/7363EDE9-D1C0-4C32-8787-7CCC332018CE/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/7363EDE9-D1C0-4C32-8787-7CCC332018CE",
+        "udid": "7363EDE9-D1C0-4C32-8787-7CCC332018CE",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-4K",
+        "state": "Shutdown",
+        "name": "Apple TV 4K"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/F171489A-D2AB-4310-B580-A9C3FECDDD3E/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/F171489A-D2AB-4310-B580-A9C3FECDDD3E",
+        "udid": "F171489A-D2AB-4310-B580-A9C3FECDDD3E",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-1080p",
+        "state": "Shutdown",
+        "name": "Apple TV 4K (at 1080p)"
+      }
+    ],
+    "com.apple.CoreSimulator.SimRuntime.watchOS-6-1": [],
+    "com.apple.CoreSimulator.SimRuntime.iOS-13-5": [
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/67D79B13-7D22-4CE4-A15C-0472EE48360D/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/67D79B13-7D22-4CE4-A15C-0472EE48360D",
+        "udid": "67D79B13-7D22-4CE4-A15C-0472EE48360D",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-8",
+        "state": "Shutdown",
+        "name": "iPhone 8"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/5EEE5EFF-A600-4623-BD14-386124A03657/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/5EEE5EFF-A600-4623-BD14-386124A03657",
+        "udid": "5EEE5EFF-A600-4623-BD14-386124A03657",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-8-Plus",
+        "state": "Shutdown",
+        "name": "iPhone 8 Plus"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/E199247A-BCBE-431A-B909-16C3A58EFC89/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/E199247A-BCBE-431A-B909-16C3A58EFC89",
+        "udid": "E199247A-BCBE-431A-B909-16C3A58EFC89",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-11",
+        "state": "Shutdown",
+        "name": "iPhone 11"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/6BEB23FC-447E-4557-A1C2-AD7919F89728/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/6BEB23FC-447E-4557-A1C2-AD7919F89728",
+        "udid": "6BEB23FC-447E-4557-A1C2-AD7919F89728",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro",
+        "state": "Shutdown",
+        "name": "iPhone 11 Pro"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/6838393D-132F-47AF-984D-CC0F9C8ED33F/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/6838393D-132F-47AF-984D-CC0F9C8ED33F",
+        "udid": "6838393D-132F-47AF-984D-CC0F9C8ED33F",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro-Max",
+        "state": "Shutdown",
+        "name": "iPhone 11 Pro Max"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/CD3BD8C5-819C-4B12-9310-E312A42F3BBC/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/CD3BD8C5-819C-4B12-9310-E312A42F3BBC",
+        "udid": "CD3BD8C5-819C-4B12-9310-E312A42F3BBC",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-SE--2nd-generation-",
+        "state": "Shutdown",
+        "name": "iPhone SE (2nd generation)"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1",
+        "udid": "A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--9-7-inch-",
+        "state": "Shutdown",
+        "name": "iPad Pro (9.7-inch)"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/F8D16DB4-8639-4BBA-9E84-0ECCB73F43E0/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/F8D16DB4-8639-4BBA-9E84-0ECCB73F43E0",
+        "udid": "F8D16DB4-8639-4BBA-9E84-0ECCB73F43E0",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPad--7th-generation-",
+        "state": "Shutdown",
+        "name": "iPad (7th generation)"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/7DE96DB3-36DB-453F-88A2-92BD79F8168D/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/7DE96DB3-36DB-453F-88A2-92BD79F8168D",
+        "udid": "7DE96DB3-36DB-453F-88A2-92BD79F8168D",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--11-inch---2nd-generation-",
+        "state": "Shutdown",
+        "name": "iPad Pro (11-inch) (2nd generation)"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/E93D9611-7AD2-4300-9245-3C7F73EA64A9/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/E93D9611-7AD2-4300-9245-3C7F73EA64A9",
+        "udid": "E93D9611-7AD2-4300-9245-3C7F73EA64A9",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---4th-generation-",
+        "state": "Shutdown",
+        "name": "iPad Pro (12.9-inch) (4th generation)"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/E569908B-F992-44D8-843C-205B7070AD9E/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/E569908B-F992-44D8-843C-205B7070AD9E",
+        "udid": "E569908B-F992-44D8-843C-205B7070AD9E",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPad-Air--3rd-generation-",
+        "state": "Booted",
+        "name": "iPad Air (3rd generation)"
+      }
+    ],
+    "com.apple.CoreSimulator.SimRuntime.watchOS-5-2": [],
+    "com.apple.CoreSimulator.SimRuntime.iOS-12-2": [],
+    "com.apple.CoreSimulator.SimRuntime.tvOS-13-0": [],
+    "com.apple.CoreSimulator.SimRuntime.watchOS-6-2": [
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/BDE9E325-C5AF-42D2-9BC2-7BF61C86A141/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/BDE9E325-C5AF-42D2-9BC2-7BF61C86A141",
+        "udid": "BDE9E325-C5AF-42D2-9BC2-7BF61C86A141",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-4-40mm",
+        "state": "Shutdown",
+        "name": "Apple Watch Series 4 - 40mm"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/56682B53-AE20-46BF-A262-6664AF9B9BC0/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/56682B53-AE20-46BF-A262-6664AF9B9BC0",
+        "udid": "56682B53-AE20-46BF-A262-6664AF9B9BC0",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-4-44mm",
+        "state": "Shutdown",
+        "name": "Apple Watch Series 4 - 44mm"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/94E2C782-65C4-4777-8A48-1417522FDA6A/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/94E2C782-65C4-4777-8A48-1417522FDA6A",
+        "udid": "94E2C782-65C4-4777-8A48-1417522FDA6A",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-5-40mm",
+        "state": "Shutdown",
+        "name": "Apple Watch Series 5 - 40mm"
+      },
+      {
+        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/3A420AFE-3C25-4914-BCE1-756015B76032/data",
+        "logPath": "/Users/admin/Library/Logs/CoreSimulator/3A420AFE-3C25-4914-BCE1-756015B76032",
+        "udid": "3A420AFE-3C25-4914-BCE1-756015B76032",
+        "isAvailable": true,
+        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-5-44mm",
+        "state": "Shutdown",
+        "name": "Apple Watch Series 5 - 44mm"
+      }
+    ],
+    "com.apple.CoreSimulator.SimRuntime.watchOS-5-3": [],
+    "com.apple.CoreSimulator.SimRuntime.iOS-12-4": [],
+    "com.apple.CoreSimulator.SimRuntime.tvOS-12-2": [],
+    "com.apple.CoreSimulator.SimRuntime.iOS-13-0": [],
+    "com.apple.CoreSimulator.SimRuntime.iOS-9-3": []
+  }
+}


### PR DESCRIPTION
Currently when finding the latest iOS version the versions are sorted by lexicographical order. I figured this was good enough at the time as we don't use iOS versions lower than 10. However, people have had issues due to iOS 9 simulators being present and `"9" > "13"`. This PR fixes this by sorting the iOS versions based on their major and minor version numbers.

Also used this as an opportunity to refactor `simulator.go` and added some tests.