### PR TITLE
Make fortunes and lazydocker optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ registries:
 
 You run can run a service or playlist by running `tb up -s <service>` or `tb up -p <playlist>`. `tb` will install any dependencies it needs and then start your services in docker containers.
 
-`tb up` will start [lazydocker](https://github.com/jesseduffield/lazydocker). For more information about how to interact with it, check out [its README](https://github.com/jesseduffield/lazydocker/blob/master/README.md). You can quit lazydocker, and containers will continue to run. You can always run `lazydocker` again without having to restart your services.
+`tb up` will start [lazydocker](https://github.com/jesseduffield/lazydocker) if [enabled](#toggling-lazydocker). For more information about how to interact with it, check out [its README](https://github.com/jesseduffield/lazydocker/blob/master/README.md). You can quit lazydocker, and containers will continue to run. You can always run `lazydocker` again without having to restart your services.
 
 Try running `tb --help` or `tb up --help` to see what else you can do.
 
@@ -123,6 +123,15 @@ Please be aware that you may encounter bugs with these features as they have not
 Also, experimental mode is not covered by semver guarantees, so there could be breaking changes at any time.
 
 If you would like to help use test new features, we would appreciate it if you could enable experimental mode and report any issues you encounter.
+
+### Toggling fortunes
+
+To toggle fortunes, set the `fortunes` property to `true` or `false`. If omitted, fortunes are enabled by default.
+
+### Toggling `lazydocker`
+
+To toggle if `lazydocker` should run after starting containers, set the `lazydocker` property to `true` or `false`. If omitted, `lazydocker` is enabled by default.
+Consequently, `lazydocker` is no longer considered a dependency if this option is disabled.
 
 ### Adding custom playlists
 You can create custom playlists by adding a new object to the `playlists` property.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,12 +52,14 @@ func init() {
 	rootCmd.AddCommand(appCmd.AppCmd(), registryCmd.RegistryCmd())
 
 	cobra.OnInitialize(func() {
-		f := fortune.Random().String()
-		fmt.Println(color.Magenta(f))
-
 		err := config.LoadTBRC()
 		if err != nil {
 			fatal.ExitErr(err, "Failed to load tbrc.")
+		}
+
+		if config.IsFortunesEnabled() {
+			f := fortune.Random().String()
+			fmt.Println(color.Magenta(f))
 		}
 
 		checkVersion()

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -195,13 +195,18 @@ Examples:
 	tb up --services postgres,localstack`,
 	Args: cobra.NoArgs,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		err := deps.Resolve(
+		var dependencies = []string{
 			deps.Brew,
 			deps.Aws,
-			deps.Lazydocker,
 			deps.Node,
 			deps.Yarn,
-		)
+		}
+
+		if config.IsLazydockerEnabled() {
+			dependencies = append(dependencies, deps.Lazydocker)
+		}
+
+		err := deps.Resolve(dependencies...)
 		if err != nil {
 			fatal.ExitErr(err, "could not resolve dependencies")
 		}
@@ -340,7 +345,7 @@ Examples:
 		dockerComposeUp(selectedServices)
 		fmt.Println()
 
-		if !opts.shouldSkipLazydocker {
+		if !opts.shouldSkipLazydocker && config.IsLazydockerEnabled() {
 			log.Info("☐ Starting lazydocker")
 			err = command.Exec("lazydocker", nil, "lazydocker")
 			if err != nil {

--- a/config/tbrc.go
+++ b/config/tbrc.go
@@ -24,6 +24,8 @@ var ErrRegistryExists = errors.New("registry already exists")
 type userConfig struct {
 	DebugEnabled        bool                               `yaml:"debug"`
 	ExperimentalEnabled bool                               `yaml:"experimental"`
+	FortunesEnabled     *bool                              `yaml:"fortunes"`
+	LazydockerEnabled   *bool                              `yaml:"lazydocker"`
 	Playlists           map[string]playlist.Playlist       `yaml:"playlists"`
 	Overrides           map[string]service.ServiceOverride `yaml:"overrides"`
 	Registries          []registry.Registry                `yaml:"registries"`
@@ -33,6 +35,14 @@ type userConfig struct {
 
 func IsExperimentalEnabled() bool {
 	return tbrc.ExperimentalEnabled
+}
+
+func IsFortunesEnabled() bool {
+	return tbrc.FortunesEnabled == nil || *tbrc.FortunesEnabled
+}
+
+func IsLazydockerEnabled() bool {
+	return tbrc.LazydockerEnabled == nil || *tbrc.LazydockerEnabled
 }
 
 func Registries() []registry.Registry {


### PR DESCRIPTION
- They are enabled by default to preserve compatibility
- Disabling `lazydocker` removes it as a dependency requirement