### PR TITLE
fix: Fetching the latest commit SHA was broken for private repos

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -148,6 +148,8 @@ update:
 		return errors.Wrap(err, "failed to create lazydocker config file")
 	}
 
+	git.CheckGithubAPIToken()
+
 	// THE REGISTRY ZONE
 
 	log.Infoln("Cloning/pulling registries...")

--- a/git/github.go
+++ b/git/github.go
@@ -5,13 +5,38 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
-	apiURL = "https://api.github.com"
+	apiURL             = "https://api.github.com"
+	githubTokenVarName = "GITHUB_TOKEN"
 )
+
+// CheckGithubAPIToken will check if the GITHUB_TOKEN env var is set.
+// It also supports HOMEBREW_GITHUB_API_TOKEN but this is deprecated.
+func CheckGithubAPIToken() {
+	log.Debugf("Checking if %s is set", githubTokenVarName)
+	token := os.Getenv(githubTokenVarName)
+	if token != "" {
+		log.Debugf("%s is set", token)
+		return
+	}
+
+	// HOMEBREW_GITHUB_API_TOKEN is supported for backwards compatibility
+	// but it's deprecated
+	const varName = "HOMEBREW_GITHUB_API_TOKEN"
+	token = os.Getenv(varName)
+	if token == "" {
+		return
+	}
+
+	log.Warnf("Using %s is deprecated. Please use %s instead.", varName, githubTokenVarName)
+	os.Setenv(githubTokenVarName, token)
+}
 
 type getBranchResponse struct {
 	Commit struct {
@@ -26,6 +51,14 @@ func GetBranchHeadSha(repo, branch string) (string, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to create GET request to GitHub API")
+	}
+
+	// Add auth token if it's set
+	hasAuth := false
+	if tokenVal := os.Getenv(githubTokenVarName); tokenVal != "" {
+		token := fmt.Sprintf("token %s", tokenVal)
+		req.Header.Add("Authorization", token)
+		hasAuth = true
 	}
 
 	// Use v3 API
@@ -43,7 +76,19 @@ func GetBranchHeadSha(repo, branch string) (string, error) {
 		return "", errors.Wrap(err, "Unable to read response body")
 	}
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
+		// GitHub responds with 404 instead of 401 if you don't have access to protect private repos
+		if res.StatusCode == http.StatusNotFound {
+			msg := fmt.Sprintf("GitHub repo: %s, branch: %s not found", repo, branch)
+
+			// Try to help people out
+			if !hasAuth {
+				msg += fmt.Sprintf("\nIf it's a private repo you need to set %s to access it", githubTokenVarName)
+			}
+
+			return "", errors.New(msg)
+		}
+
 		return "", errors.Errorf("Got %d response from GitHub API:\n%s", res.StatusCode, string(body))
 	}
 
@@ -81,7 +126,7 @@ func GetLatestRelease() (string, error) {
 		return "", errors.Wrap(err, "Unable to read response body")
 	}
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		return "", errors.Errorf("Got %d response from GitHub API:\n%s", res.StatusCode, string(body))
 	}
 


### PR DESCRIPTION
Add back support for `HOMEBREW_GITHUB_API_TOKEN` since it is required for `tb app ios run`. However, deprecate it in favour of `GITHUB_TOKEN`. Add helpful error message if auth is missing.

PR that broke this: https://github.com/TouchBistro/tb/pull/283