### PR TITLE
feat: Improve registry validation, error if unknown variables are used

### DIFF
--- a/cmd/registry/validate.go
+++ b/cmd/registry/validate.go
@@ -10,6 +10,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type validateOptions struct {
+	strict bool
+}
+
+var validateOpts validateOptions
+
 var validateCmd = &cobra.Command{
 	Use:   "validate <path>",
 	Args:  cobra.ExactArgs(1),
@@ -24,7 +30,7 @@ Example:
 		log.Infof(color.Cyan("Validating registry files at path %s..."), registryPath)
 
 		valid := true
-		result := registry.Validate(registryPath)
+		result := registry.Validate(registryPath, validateOpts.strict)
 		if errors.Is(result.AppsErr, registry.ErrFileNotExist) {
 			log.Infof(color.Yellow("No %s file"), registry.AppsFileName)
 		} else if result.AppsErr == nil {
@@ -60,5 +66,6 @@ Example:
 }
 
 func init() {
+	validateCmd.Flags().BoolVar(&validateOpts.strict, "strict", false, "Strict mode, treat more cases as errors")
 	registryCmd.AddCommand(validateCmd)
 }

--- a/cmd/registry/validate.go
+++ b/cmd/registry/validate.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"errors"
+
 	"github.com/TouchBistro/goutils/color"
 	"github.com/TouchBistro/goutils/fatal"
 	"github.com/TouchBistro/tb/registry"
@@ -21,11 +23,38 @@ Example:
 		registryPath := args[0]
 		log.Infof(color.Cyan("Validating registry files at path %s..."), registryPath)
 
-		err := registry.Validate(registryPath)
-		if err != nil {
-			fatal.ExitErrf(err, "failed to validate registry at path %s", registryPath)
+		valid := true
+		result := registry.Validate(registryPath)
+		if errors.Is(result.AppsErr, registry.ErrFileNotExist) {
+			log.Infof(color.Yellow("No %s file"), registry.AppsFileName)
+		} else if result.AppsErr == nil {
+			log.Infof(color.Green("✅ %s is valid"), registry.AppsFileName)
+		} else {
+			log.Infof("❌ %s is invalid\n%v", registry.AppsFileName, result.AppsErr)
+			valid = false
 		}
 
+		if errors.Is(result.PlaylistsErr, registry.ErrFileNotExist) {
+			log.Infof(color.Yellow("No %s file"), registry.PlaylistsFileName)
+		} else if result.PlaylistsErr == nil {
+			log.Infof(color.Green("✅ %s is valid"), registry.PlaylistsFileName)
+		} else {
+			log.Infof("❌ %s is invalid\n%v", registry.PlaylistsFileName, result.PlaylistsErr)
+			valid = false
+		}
+
+		if errors.Is(result.ServicesErr, registry.ErrFileNotExist) {
+			log.Infof(color.Yellow("No %s file"), registry.ServicesFileName)
+		} else if result.ServicesErr == nil {
+			log.Infof(color.Green("✅ %s is valid"), registry.ServicesFileName)
+		} else {
+			log.Infof("❌ %s is invalid\n%v", registry.ServicesFileName, result.ServicesErr)
+			valid = false
+		}
+
+		if !valid {
+			fatal.Exit(color.Red("❌ registry is invalid"))
+		}
 		log.Info(color.Green("✅ registry is valid"))
 	},
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -316,7 +316,7 @@ func expandVarsInField(field *string, vars map[string]string, errMsgs *[]string,
 		return
 	}
 
-	msg := fmt.Sprintf("%s: %s", fieldName, err.Error())
+	msg := fmt.Sprintf("%s: %s", fieldName, err)
 	*errMsgs = append(*errMsgs, msg)
 }
 
@@ -496,6 +496,13 @@ type ValidateResult struct {
 	ServicesErr  error
 }
 
+// Validate checks to see if the registry located at path is valid. It will read and validate
+// each configuration file in the registry.
+//
+// Validate returns a ValidateResult struct that contains errors encountered for each resource.
+// If a configuration file is valid, then the corresponding error value will be nil. Otherwise,
+// the error will be a non-nil value containing the details of why validation failed.
+// If a configuration file does not exist, then the corresponding error will be ErrFileNotExist.
 func Validate(path string) ValidateResult {
 	r := Registry{
 		Name: filepath.Base(path),

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/TouchBistro/goutils/color"
 	"github.com/TouchBistro/goutils/file"
 	"github.com/TouchBistro/tb/app"
 	"github.com/TouchBistro/tb/playlist"
@@ -19,11 +18,19 @@ import (
 
 // File names in registry
 const (
-	appsFileName      = "apps.yml"
-	playlistsFileName = "playlists.yml"
-	servicesFileName  = "services.yml"
+	AppsFileName      = "apps.yml"
+	PlaylistsFileName = "playlists.yml"
+	ServicesFileName  = "services.yml"
 	staticDirName     = "static"
 )
+
+const (
+	resourceTypeApp     = "app"
+	resourceTypeService = "service"
+)
+
+// ErrFileNotExist indicates a registry file does not exist.
+var ErrFileNotExist = os.ErrNotExist
 
 // TODO(@cszatmary): Figure out a better way to differentiate between app types
 type appType int
@@ -75,6 +82,42 @@ type RegistryResult struct {
 	LoginStrategies []string
 }
 
+// ValidationError represents a resource having failed validation.
+// It contains the resource type, name, and a list of validation
+// failure messages.
+type ValidationError struct {
+	ResourceType string
+	ResourceName string
+	Messages     []string
+}
+
+func (ve *ValidationError) Error() string {
+	var sb strings.Builder
+	sb.WriteString(ve.ResourceType)
+	sb.WriteString(": ")
+	sb.WriteString(ve.ResourceName)
+	sb.WriteString(": ")
+
+	for i, msg := range ve.Messages {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(msg)
+	}
+	return sb.String()
+}
+
+// ErrorList is a list of errors encountered.
+type ErrorList []error
+
+func (e ErrorList) Error() string {
+	errStrs := make([]string, len(e))
+	for i, err := range e {
+		errStrs[i] = err.Error()
+	}
+	return strings.Join(errStrs, "\n")
+}
+
 func readRegistryFile(fileName string, r Registry, v interface{}) error {
 	log.Debugf("Reading %s from registry %s", fileName, r.Name)
 
@@ -96,22 +139,33 @@ func readRegistryFile(fileName string, r Registry, v interface{}) error {
 }
 
 func validateService(s service.Service) error {
+	var msgs []string
+
 	// Make sure mode is a valid value
 	if s.Mode != service.ModeRemote && s.Mode != service.ModeBuild {
-		return errors.Errorf("'%s.mode' value is invalid must be 'remote' or 'build'", s.Name)
+		msg := fmt.Sprintf("invalid 'mode' value %q, must be 'remote' or 'build'", s.Mode)
+		msgs = append(msgs, msg)
 	}
 
 	// Make sure image is specified if using remote
 	if s.UseRemote() && s.Remote.Image == "" {
-		return errors.Errorf("'%s.mode' is set to 'remote' but 'remote.image' was not provided", s.Name)
+		msgs = append(msgs, "'mode' is set to 'remote' but 'remote.image' was not provided")
 	}
 
 	// Make sure repo is specified if not using remote
 	if !s.UseRemote() && !s.CanBuild() {
-		return errors.Errorf("'%s.mode' is set to 'build' but 'build.dockerfilePath' was not provided", s.Name)
+		msgs = append(msgs, "'mode' is set to 'build' but 'build.dockerfilePath' was not provided")
 	}
 
-	return nil
+	if msgs == nil {
+		return nil
+	}
+
+	return &ValidationError{
+		ResourceType: resourceTypeService,
+		ResourceName: s.Name,
+		Messages:     msgs,
+	}
 }
 
 func validateApp(a app.App, t appType) error {
@@ -120,12 +174,22 @@ func validateApp(a app.App, t appType) error {
 		return nil
 	}
 
+	var msgs []string
+
 	// Make sure RunsOn is valid
 	if a.DeviceType() == app.DeviceTypeUnknown {
-		return errors.Errorf("'%s.runsOn' value is invalid, must be 'all', 'ipad', or 'iphone'", a.Name)
+		msgs = append(msgs, "'runsOn' value is invalid, must be 'all', 'ipad', or 'iphone'")
 	}
 
-	return nil
+	if msgs == nil {
+		return nil
+	}
+
+	return &ValidationError{
+		ResourceType: resourceTypeApp,
+		ResourceName: a.Name,
+		Messages:     msgs,
+	}
 }
 
 type readServicesOptions struct {
@@ -136,12 +200,10 @@ type readServicesOptions struct {
 
 func readServices(r Registry, opts readServicesOptions) ([]service.Service, serviceGlobalConfig, error) {
 	serviceConf := registryServiceConfig{}
-	err := readRegistryFile(servicesFileName, r, &serviceConf)
+	err := readRegistryFile(ServicesFileName, r, &serviceConf)
 	if err != nil {
 		return nil, serviceGlobalConfig{}, errors.Wrapf(err, "failed to read services file from registry %s", r.Name)
 	}
-
-	services := make([]service.Service, 0, len(serviceConf.Services))
 
 	// Set special vars
 	vars := serviceConf.Global.Variables
@@ -160,13 +222,15 @@ func readServices(r Registry, opts readServicesOptions) ([]service.Service, serv
 		vars["@"+name] = util.DockerName(fullName)
 	}
 
+	services := make([]service.Service, 0, len(serviceConf.Services))
+	var errs ErrorList
 	for n, s := range serviceConf.Services {
 		s.Name = n
 		s.RegistryName = r.Name
 
-		err := validateService(s)
-		if err != nil {
-			return nil, serviceGlobalConfig{}, errors.Wrapf(err, "service %s failed validation", n)
+		if err := validateService(s); err != nil {
+			errs = append(errs, err)
+			continue
 		}
 
 		override, ok := opts.overrides[s.FullName()]
@@ -187,27 +251,50 @@ func readServices(r Registry, opts readServicesOptions) ([]service.Service, serv
 		vars["@REPOPATH"] = repoPath
 
 		// Expand any vars
+		var errMsgs []string
 		for i, dep := range s.Dependencies {
-			s.Dependencies[i] = util.ExpandVars(dep, vars)
+			d := dep
+			expandVarsInField(&d, vars, &errMsgs, "dependencies")
+			s.Dependencies[i] = d
 		}
 
-		s.Build.DockerfilePath = util.ExpandVars(s.Build.DockerfilePath, vars)
-		s.EnvFile = util.ExpandVars(s.EnvFile, vars)
-		s.Remote.Image = util.ExpandVars(s.Remote.Image, vars)
+		expandVarsInField(&s.Build.DockerfilePath, vars, &errMsgs, "build.dockerfilePath")
+		expandVarsInField(&s.EnvFile, vars, &errMsgs, "envFile")
+		expandVarsInField(&s.Remote.Image, vars, &errMsgs, "remote.image")
 
 		for key, value := range s.EnvVars {
-			s.EnvVars[key] = util.ExpandVars(value, vars)
+			v := value
+			expandVarsInField(&v, vars, &errMsgs, "envVars")
+			s.EnvVars[key] = v
 		}
 
 		for i, volume := range s.Build.Volumes {
-			s.Build.Volumes[i].Value = util.ExpandVars(volume.Value, vars)
+			v := volume.Value
+			expandVarsInField(&v, vars, &errMsgs, "build.volumes")
+			s.Build.Volumes[i].Value = v
 		}
 
 		for i, volume := range s.Remote.Volumes {
-			s.Remote.Volumes[i].Value = util.ExpandVars(volume.Value, vars)
+			v := volume.Value
+			expandVarsInField(&v, vars, &errMsgs, "remote.volumes")
+			s.Remote.Volumes[i].Value = v
+
+		}
+
+		if len(errMsgs) > 0 {
+			errs = append(errs, &ValidationError{
+				ResourceType: resourceTypeService,
+				ResourceName: s.Name,
+				Messages:     errMsgs,
+			})
+			continue
 		}
 
 		services = append(services, s)
+	}
+
+	if errs != nil {
+		return nil, serviceGlobalConfig{}, errs
 	}
 
 	globalConf := serviceGlobalConfig{
@@ -218,9 +305,24 @@ func readServices(r Registry, opts readServicesOptions) ([]service.Service, serv
 	return services, globalConf, nil
 }
 
+// expandVarsInField is a small helper to expand vars in a service field
+// and report any errors. If the expansion is successful, the value pointed to
+// by field will be updated. If an error occurs, the error message will be appended
+// to errMsgs.
+func expandVarsInField(field *string, vars map[string]string, errMsgs *[]string, fieldName string) {
+	e, err := util.ExpandVars(*field, vars)
+	if err == nil {
+		*field = e
+		return
+	}
+
+	msg := fmt.Sprintf("%s: %s", fieldName, err.Error())
+	*errMsgs = append(*errMsgs, msg)
+}
+
 func readPlaylists(r Registry) ([]playlist.Playlist, error) {
 	playlistMap := make(map[string]playlist.Playlist)
-	err := readRegistryFile(playlistsFileName, r, &playlistMap)
+	err := readRegistryFile(PlaylistsFileName, r, &playlistMap)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read playlist file from registry %s", r.Name)
 	}
@@ -268,28 +370,28 @@ func readPlaylists(r Registry) ([]playlist.Playlist, error) {
 
 func readApps(r Registry) ([]app.App, []app.App, error) {
 	appConf := registryAppConfig{}
-	err := readRegistryFile(appsFileName, r, &appConf)
+	err := readRegistryFile(AppsFileName, r, &appConf)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to read apps file from registry %s", r.Name)
 	}
 
-	iosApps := make([]app.App, 0, len(appConf.IOSApps))
-	desktopApps := make([]app.App, 0, len(appConf.DesktopApps))
+	var errs ErrorList
 
 	// Deal with iOS apps
+	iosApps := make([]app.App, 0, len(appConf.IOSApps))
 	for n, a := range appConf.IOSApps {
 		a.Name = n
 		a.RegistryName = r.Name
 
-		err := validateApp(a, appTypeiOS)
-		if err != nil {
-			return nil, nil, errors.Wrapf(err, "app %s failed validation", n)
+		if err := validateApp(a, appTypeiOS); err != nil {
+			errs = append(errs, err)
 		}
 
 		iosApps = append(iosApps, a)
 	}
 
 	// Deal with desktop apps
+	desktopApps := make([]app.App, 0, len(appConf.DesktopApps))
 	for n, a := range appConf.DesktopApps {
 		a.Name = n
 		a.RegistryName = r.Name
@@ -297,6 +399,9 @@ func readApps(r Registry) ([]app.App, []app.App, error) {
 		desktopApps = append(desktopApps, a)
 	}
 
+	if errs != nil {
+		return nil, nil, errs
+	}
 	return iosApps, desktopApps, nil
 }
 
@@ -385,108 +490,86 @@ func ReadRegistries(registries []Registry, opts ReadOptions) (RegistryResult, er
 	}, nil
 }
 
-func Validate(path string) error {
+type ValidateResult struct {
+	AppsErr      error
+	PlaylistsErr error
+	ServicesErr  error
+}
+
+func Validate(path string) ValidateResult {
+	r := Registry{
+		Name: filepath.Base(path),
+		Path: path,
+	}
+	result := ValidateResult{}
+
 	// Validate apps.yml
-	log.Infof(color.Cyan("Validating %s..."), appsFileName)
 
-	appsPath := filepath.Join(path, appsFileName)
+	// Do explicit check for existence because we want to print a custom message
+	// If it doesn't exist
+	appsPath := filepath.Join(path, AppsFileName)
 	if file.FileOrDirExists(appsPath) {
-		af, err := os.Open(appsPath)
+		_, _, err := readApps(r)
 		if err != nil {
-			return errors.Wrapf(err, "failed to open file %s", appsPath)
+			result.AppsErr = err
 		}
-		defer af.Close()
-
-		appConf := registryAppConfig{}
-		err = yaml.NewDecoder(af).Decode(&appConf)
-		if err != nil {
-			return errors.Wrapf(err, "failed to read %s", appsPath)
-		}
-
-		// Make sure all iOS apps are valid
-		for n, a := range appConf.IOSApps {
-			a.Name = n
-			err := validateApp(a, appTypeiOS)
-			if err != nil {
-				log.Infof(color.Red("❌ app %s is invalid"), n)
-				return errors.Wrapf(err, "app %s failed validation", n)
-			}
-		}
-
-		log.Infof(color.Green("✅ %s is valid"), appsFileName)
 	} else {
-		log.Infof(color.Yellow("No %s file"), appsFileName)
+		result.AppsErr = fmt.Errorf("%w: %s", ErrFileNotExist, AppsFileName)
 	}
 
 	// Validate playlists.yml
-	log.Infof(color.Cyan("Validating %s..."), playlistsFileName)
 
-	playlistsPath := filepath.Join(path, playlistsFileName)
+	playlistsPath := filepath.Join(path, PlaylistsFileName)
 	if file.FileOrDirExists(playlistsPath) {
-		pf, err := os.Open(playlistsPath)
+		_, err := readPlaylists(r)
 		if err != nil {
-			return errors.Wrapf(err, "failed to open file %s", playlistsPath)
+			result.PlaylistsErr = err
 		}
-		defer pf.Close()
-
-		playlistMap := make(map[string]playlist.Playlist)
-		err = yaml.NewDecoder(pf).Decode(&playlistMap)
-		if err != nil {
-			return errors.Wrapf(err, "failed to read %s", playlistsPath)
-		}
-
-		log.Infof(color.Green("✅ %s is valid"), playlistsFileName)
 	} else {
-		log.Infof(color.Yellow("No %s file"), playlistsFileName)
+		result.PlaylistsErr = fmt.Errorf("%w: %s", ErrFileNotExist, PlaylistsFileName)
 	}
 
 	// Validate services.yml
-	log.Infof(color.Cyan("Validating %s..."), servicesFileName)
 
-	servicesPath := filepath.Join(path, servicesFileName)
+	servicesPath := filepath.Join(path, ServicesFileName)
 	if file.FileOrDirExists(servicesPath) {
-		sf, err := os.Open(servicesPath)
-		if err != nil {
-			return errors.Wrapf(err, "failed to open file %s", servicesPath)
-		}
-		defer sf.Close()
+		services, _, err := readServices(r, readServicesOptions{})
+		if err == nil {
+			// Keep track of ports to check for conflicting ports
+			usedPorts := make(map[string]string)
 
-		serviceConf := registryServiceConfig{}
-		err = yaml.NewDecoder(sf).Decode(&serviceConf)
-		if err != nil {
-			return errors.Wrapf(err, "failed to read %s", servicesPath)
-		}
+			// Perform additional validations
+			var errs ErrorList
+			for _, s := range services {
+				// Check for port conflict
+				for _, p := range s.Ports {
+					// ports are of the form EXTERNAL:INTERNAL
+					// get external part
+					exposedPort := strings.Split(p, ":")[0]
+					conflict, ok := usedPorts[exposedPort]
+					if !ok {
+						usedPorts[exposedPort] = s.Name
+						continue
+					}
 
-		// Keep track of ports to check for conflicting ports
-		usedPorts := make(map[string]string)
-
-		// Make sure all services are valid
-		for n, s := range serviceConf.Services {
-			s.Name = n
-			err := validateService(s)
-			if err != nil {
-				log.Infof(color.Red("❌ service %s is invalid"), n)
-				return errors.Wrapf(err, "service %s failed validation", n)
-			}
-
-			// Check for port conflict
-			for _, p := range s.Ports {
-				// ports are of the form EXTERNAL:INTERNAL
-				// get external part
-				exposedPort := strings.Split(p, ":")[0]
-				if conflict, ok := usedPorts[exposedPort]; ok {
-					log.Infof(color.Red("❌ service %s has conflicting port %s with service %s"), n, exposedPort, conflict)
-					return errors.Errorf("service %s failed validation", n)
+					// Handle port conflict
+					msg := fmt.Sprintf("conflicting port %s with service %s", exposedPort, conflict)
+					errs = append(errs, &ValidationError{
+						ResourceType: resourceTypeService,
+						ResourceName: s.Name,
+						Messages:     []string{msg},
+					})
 				}
-
-				usedPorts[exposedPort] = n
 			}
+			if errs != nil {
+				result.ServicesErr = errs
+			}
+		} else {
+			result.ServicesErr = err
 		}
-
-		log.Infof(color.Green("✅ %s is valid"), servicesFileName)
 	} else {
-		log.Infof(color.Yellow("No %s file"), servicesFileName)
+		result.ServicesErr = fmt.Errorf("%w: %s", ErrFileNotExist, ServicesFileName)
 	}
 
-	return nil
+	return result
 }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -268,14 +268,14 @@ func TestReadRegistries(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	result := registry.Validate("testdata/registry-2")
+	result := registry.Validate("testdata/registry-2", true)
 	assert.NoError(t, result.AppsErr)
 	assert.NoError(t, result.PlaylistsErr)
 	assert.NoError(t, result.ServicesErr)
 }
 
 func TestValidateErrors(t *testing.T) {
-	result := registry.Validate("testdata/invalid-registry-1")
+	result := registry.Validate("testdata/invalid-registry-1", true)
 
 	var errList registry.ErrorList
 	var validationErr *registry.ValidationError

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,10 +1,13 @@
-package registry
+package registry_test
 
 import (
+	"errors"
+	"sort"
 	"testing"
 
 	"github.com/TouchBistro/tb/app"
 	"github.com/TouchBistro/tb/playlist"
+	"github.com/TouchBistro/tb/registry"
 	"github.com/TouchBistro/tb/service"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,17 +15,17 @@ import (
 func TestReadRegistries(t *testing.T) {
 	assert := assert.New(t)
 
-	registries := []Registry{
-		Registry{
+	registries := []registry.Registry{
+		{
 			Name: "TouchBistro/tb-registry",
 			Path: "testdata/registry-1",
 		},
-		Registry{
+		{
 			Name: "ExampleZone/tb-registry",
 			Path: "testdata/registry-2",
 		},
 	}
-	result, err := ReadRegistries(registries, ReadOptions{
+	result, err := registry.ReadRegistries(registries, registry.ReadOptions{
 		ShouldReadApps:     true,
 		ShouldReadServices: true,
 		RootPath:           "/home/test/.tb",
@@ -265,17 +268,42 @@ func TestReadRegistries(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	assert := assert.New(t)
-
-	err := Validate("testdata/registry-1")
-
-	assert.NoError(err)
+	result := registry.Validate("testdata/registry-2")
+	assert.NoError(t, result.AppsErr)
+	assert.NoError(t, result.PlaylistsErr)
+	assert.NoError(t, result.ServicesErr)
 }
 
-func TestValidateInvalidService(t *testing.T) {
-	assert := assert.New(t)
+func TestValidateErrors(t *testing.T) {
+	result := registry.Validate("testdata/invalid-registry-1")
 
-	err := Validate("testdata/invalid-registry-1")
+	var errList registry.ErrorList
+	var validationErr *registry.ValidationError
 
-	assert.Error(err)
+	assert.True(t, errors.As(result.AppsErr, &errList))
+	assert.Len(t, errList, 1)
+	assert.True(t, errors.As(errList[0], &validationErr))
+	assert.Equal(t, "app", validationErr.ResourceType)
+	assert.Equal(t, "GemSwapper", validationErr.ResourceName)
+
+	assert.True(t, errors.Is(result.PlaylistsErr, registry.ErrFileNotExist))
+
+	assert.True(t, errors.As(result.ServicesErr, &errList))
+	assert.Len(t, errList, 3)
+	var serviceErrs []*registry.ValidationError
+	for _, err := range errList {
+		var ve *registry.ValidationError
+		assert.True(t, errors.As(err, &ve))
+		assert.Equal(t, "service", ve.ResourceType)
+		serviceErrs = append(serviceErrs, ve)
+	}
+	// The order the services are unmarshed in is not guaranteed so sort them
+	// to make sure the test isn't flaky
+	sort.Slice(serviceErrs, func(i, j int) bool {
+		return serviceErrs[i].ResourceName < serviceErrs[j].ResourceName
+	})
+
+	assert.Equal(t, "postgres", serviceErrs[0].ResourceName)
+	assert.Equal(t, "venue-core-service", serviceErrs[1].ResourceName)
+	assert.Equal(t, "venue-example-service", serviceErrs[2].ResourceName)
 }

--- a/registry/testdata/invalid-registry-1/apps.yml
+++ b/registry/testdata/invalid-registry-1/apps.yml
@@ -1,0 +1,17 @@
+iosApps:
+  GemSwapper:
+    bundleID: com.example.GemSwapper
+    branch: master
+    repo: ExampleZone/gem-swapper
+    runsOn: iFoot
+    storage:
+      provider: s3
+      bucket: ios-builds
+  iCode:
+    bundleID: com.example.iCode
+    branch: develop
+    repo: ExampleZone/iCode
+    runsOn: iPad
+    storage:
+      provider: s3
+      bucket: ios-builds

--- a/registry/testdata/invalid-registry-1/services.yml
+++ b/registry/testdata/invalid-registry-1/services.yml
@@ -3,7 +3,7 @@ services:
     envVars:
       POSTGRES_USER: core
       POSTGRES_PASSWORD: localdev
-    mode: remote
+    mode: build
     ports:
       - '5432:5432'
   venue-core-service:
@@ -15,7 +15,7 @@ services:
       DB_HOST: ${@postgres}
     mode: local
     ports:
-      - '5432:8080'
+      - '9000:8080'
     preRun: yarn db:prepare
     repo:
       name: TouchBistro/venue-core-service
@@ -32,3 +32,25 @@ services:
       command: yarn serve
       image: venue-core-service
       tag: master
+  venue-example-service:
+    dependencies:
+      - ${@redis}
+    entrypoint: ["bash", "entrypoints/docker.sh"]
+    envFile: ${@REPOPATH}/.env.compose
+    envVars:
+      HTTP_PORT: 8000
+      POSTGRES_HOST: ${@postgres}
+    mode: local
+    ports:
+      - '9000:8000'
+    preRun: yarn db:prepare:dev
+    repo:
+      name: ExampleZone/venue-example-service
+    build:
+      target: build
+      command: yarn start
+      dockerfilePath: ${@REPOPATH}
+    remote:
+      command: yarn serve
+      image: ${docker}/venue-example-service
+      tag: staging

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,8 +1,9 @@
-package util
+package util_test
 
 import (
 	"testing"
 
+	"github.com/TouchBistro/tb/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,10 +16,23 @@ func TestExpandVars(t *testing.T) {
 		"name":      "node-boilerplate",
 	}
 
-	expanded := ExpandVars(str, vars)
+	expanded, err := util.ExpandVars(str, vars)
 
 	expected := `envPath: ${HOME}/.tb/repos/node-boilerplate`
 	assert.Equal(expected, expanded)
+	assert.NoError(err)
+}
+
+func TestExpandVarsMissingVar(t *testing.T) {
+	assert := assert.New(t)
+
+	str := `DB_HOST: ${@postgres}`
+	vars := map[string]string{}
+
+	expanded, err := util.ExpandVars(str, vars)
+
+	assert.Empty(expanded)
+	assert.Error(err)
 }
 
 func TestUnqiueStrings(t *testing.T) {
@@ -26,7 +40,7 @@ func TestUnqiueStrings(t *testing.T) {
 
 	s := []string{"npm", "ecr", "ecr", "gcp", "npm", "ecr"}
 	expected := []string{"npm", "ecr", "gcp"}
-	result := UniqueStrings(s)
+	result := util.UniqueStrings(s)
 
 	assert.Equal(expected, result)
 }
@@ -35,7 +49,7 @@ func TestSplitNameParts(t *testing.T) {
 	assert := assert.New(t)
 
 	name := "TouchBistro/tb-registry/touchbistro-node-boilerplate"
-	registryName, serviceName, err := SplitNameParts(name)
+	registryName, serviceName, err := util.SplitNameParts(name)
 
 	assert.Equal("TouchBistro/tb-registry", registryName)
 	assert.Equal("touchbistro-node-boilerplate", serviceName)
@@ -46,7 +60,7 @@ func TestSplitNamePartsShortName(t *testing.T) {
 	assert := assert.New(t)
 
 	name := "touchbistro-node-boilerplate"
-	registryName, serviceName, err := SplitNameParts(name)
+	registryName, serviceName, err := util.SplitNameParts(name)
 
 	assert.Empty(registryName)
 	assert.Equal("touchbistro-node-boilerplate", serviceName)
@@ -57,7 +71,7 @@ func TestSplitNamePartsInvalid(t *testing.T) {
 	assert := assert.New(t)
 
 	name := "TouchBistro/touchbistro-node-boilerplate"
-	registryName, serviceName, err := SplitNameParts(name)
+	registryName, serviceName, err := util.SplitNameParts(name)
 
 	assert.Empty(registryName)
 	assert.Empty(serviceName)
@@ -68,7 +82,7 @@ func TestDockerName(t *testing.T) {
 	assert := assert.New(t)
 
 	name := "TouchBistro/tb-registry/touchbistro-node-boilerplate"
-	dockerName := DockerName(name)
+	dockerName := util.DockerName(name)
 
 	expected := "touchbistro-tb-registry-touchbistro-node-boilerplate"
 	assert.Equal(expected, dockerName)


### PR DESCRIPTION
When reading a registry, detailed validation errors are recorded and reported. Instead of simply aborting after the first error, validation/parsing of a registry will continue if the error is not critical (ex: failing to read the file is will cause it to abort like before). This allows all the errors in a registry to be reported at once, allowing users to identify and fix all the issues instead of one at a time.

Additionally:
* `tb registry validate` has received a complete overhaul. The majority of this was thanks to the changes mentioned above. By using the detailed errors returned, a much better output is generated for the user.
* `tb registry validate` has a `--strict` flag which will error if unknown variables are encountered in a `services.yml` file. Currently, unknown variables were silently ignored and replaced with `""`. This was an unintended bug, which caused issues as tb would not report any errors, but then services would not behave as expected. However, changing this now would technically be a breaking change. As a result this solution has been designed in a non-breaking way. Users can opt into detecting unknown variables, but it will not be forced by default. In the future if we do a breaking change we could make this required.

#### `tb registry validate` before
![image](https://user-images.githubusercontent.com/22629536/103306875-a41e1600-49dc-11eb-9450-c06fc35af469.png)

#### `tb registry validate` after
![image](https://user-images.githubusercontent.com/22629536/103307126-581fa100-49dd-11eb-9183-4c0ce6aa9947.png)

