### PR TITLE
fix: prefer docker-compose-v1 to work around race condition changes in Compose V2 RC3

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -307,11 +307,12 @@ Examples:
 			log.Info("☐ performing preRun step for services")
 
 			for _, s := range selectedServices {
+				name := s.FullName()
 				if s.PreRun == "" {
+					log.Infof("\t☐ no preRun command for %s, continuing...\n", name)
 					continue
 				}
 
-				name := s.FullName()
 				log.Infof("\t☐ running preRun command %s for %s. this may take a long time.\n", s.PreRun, name)
 
 				err := docker.ComposeRun(s.DockerName(), s.PreRun)

--- a/docker/compose.go
+++ b/docker/compose.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"os/exec"
 	"strconv"
 	"strings"
 
@@ -15,6 +16,17 @@ const (
 	stopTimeoutSecs = 2
 )
 
+func composeCommand() string {
+	_, err := exec.LookPath("docker-compose-v1")
+	if err == nil {
+		log.Debugf("docker-compose-v1 exists, using it to avoid race condition issue with Docker Compose version v2.0.0-rc.3...")
+		return "docker-compose-v1"
+	}
+
+	log.Debugf("docker-compose-v1 does not exist, falling back to docker-compose (this might break if using Docker Compose version v2.0.0-rc.3)...")
+	return "docker-compose"
+}
+
 func composeFile() string {
 	return fmt.Sprintf("%s/docker-compose.yml", config.TBRootPath())
 }
@@ -22,7 +34,7 @@ func composeFile() string {
 func ComposeExec(serviceName string, execArgs []string, cmd *command.Command) error {
 	args := []string{"-f", composeFile(), "exec", serviceName}
 	args = append(args, execArgs...)
-	err := cmd.Exec("docker-compose", args...)
+	err := cmd.Exec(composeCommand(), args...)
 	if err != nil {
 		return errors.Wrap(err, "failed to run docker-compose exec")
 	}
@@ -32,7 +44,7 @@ func ComposeExec(serviceName string, execArgs []string, cmd *command.Command) er
 func ComposeLogs(services []string, cmd *command.Command) error {
 	args := []string{"-f", composeFile(), "logs", "-f"}
 	args = append(args, services...)
-	err := cmd.Exec("docker-compose", args...)
+	err := cmd.Exec(composeCommand(), args...)
 	if err != nil {
 		return errors.Wrap(err, "failed to run docker-compose logs")
 	}
@@ -69,7 +81,7 @@ func execDockerCompose(subcmd string, args ...string) error {
 	defer w.Close()
 	cmd := command.New(command.WithStdout(w), command.WithStderr(w))
 	args = append([]string{"-f", composeFile(), subcmd}, args...)
-	err := cmd.Exec("docker-compose", args...)
+	err := cmd.Exec(composeCommand(), args...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to run docker-compose %s", subcmd)
 	}

--- a/docker/compose.go
+++ b/docker/compose.go
@@ -16,15 +16,24 @@ const (
 	stopTimeoutSecs = 2
 )
 
+var _composeCommand string
+
 func composeCommand() string {
-	_, err := exec.LookPath("docker-compose-v1")
-	if err == nil {
-		log.Debugf("docker-compose-v1 exists, using it to avoid race condition issue with Docker Compose version v2.0.0-rc.3...")
-		return "docker-compose-v1"
+	if _composeCommand != "" {
+		return _composeCommand
 	}
 
-	log.Debugf("docker-compose-v1 does not exist, falling back to docker-compose (this might break if using Docker Compose version v2.0.0-rc.3)...")
-	return "docker-compose"
+	_, err := exec.LookPath("docker-compose-v1")
+
+	if err == nil {
+		log.Debugf("docker-compose-v1 exists, using it to avoid race condition issue with Docker Compose version v2.0.0-rc.3...")
+		_composeCommand = "docker-compose-v1"
+	} else {
+		log.Debugf("docker-compose-v1 does not exist, falling back to docker-compose (this might break if using Docker Compose version v2.0.0-rc.3)...")
+		_composeCommand = "docker-compose"
+	}
+
+	return _composeCommand
 }
 
 func composeFile() string {

--- a/docker/compose.go
+++ b/docker/compose.go
@@ -16,24 +16,24 @@ const (
 	stopTimeoutSecs = 2
 )
 
-var _composeCommand string
+var composeCmd string
 
 func composeCommand() string {
-	if _composeCommand != "" {
-		return _composeCommand
+	if composeCmd != "" {
+		return composeCmd
 	}
 
 	_, err := exec.LookPath("docker-compose-v1")
 
 	if err == nil {
 		log.Debugf("docker-compose-v1 exists, using it to avoid race condition issue with Docker Compose version v2.0.0-rc.3...")
-		_composeCommand = "docker-compose-v1"
+		composeCmd = "docker-compose-v1"
 	} else {
 		log.Debugf("docker-compose-v1 does not exist, falling back to docker-compose (this might break if using Docker Compose version v2.0.0-rc.3)...")
-		_composeCommand = "docker-compose"
+		composeCmd = "docker-compose"
 	}
 
-	return _composeCommand
+	return composeCmd
 }
 
 func composeFile() string {


### PR DESCRIPTION
Slack context: https://touchbistro.slack.com/archives/CU7JQ7ZPS/p1631815389225500

After upgrading to Docker for Mac 4.0.1, it appears [something changed](https://github.com/docker/compose/commit/21d3b19e57565be3cf89a61c8d521a8f3bec13c6) in [Docker Compose V2 RC3](https://github.com/docker/compose/releases/tag/v2.0.0-rc.3) that causes some of our preRun scripts to fail with the following:

```
DEBU Error response from daemon: You cannot remove a running container 96107f4682cc81f739d74a696b4a1cee4ddce7663f468d94658c5224be8c8725. Stop the container before attempting removal or force remove  id=docker-compose-run
```

We have some [fairly complex interdependencies with preRun scripts](https://github.com/TouchBistro/tb-registry/blob/20ed9de1e738d9443dff55268a65a231542b412d/services.yml#L186-L211) and we may have been depending on racy behaviour that was fixed.

This PR changes `tb` to prefer `docker-compose-v1` which is still distributed as a binary with Docker for Mac (but for how long, who can tell). 