### PR TITLE
feat: Prompt to select what to nuke and iOS simulator

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/TouchBistro/goutils/log"
@@ -15,21 +14,6 @@ import (
 	"github.com/TouchBistro/tb/engine"
 	"github.com/spf13/cobra"
 )
-
-// Prompt prompts the user for the answer to a yes/no question.
-func Prompt(msg string) bool {
-	// check for yes and assume no on any other input to avoid annoyance
-	fmt.Print(msg)
-	var resp string
-	_, err := fmt.Scanln(&resp)
-	if err != nil {
-		return false
-	}
-	if strings.ToLower(string(resp[0])) == "y" {
-		return true
-	}
-	return false
-}
 
 // ExpectSingleArg returns a function that validates the command only receives a single arg.
 // name is the name of the arg and is used in the error message.

--- a/cli/commands/app/ios/ios.go
+++ b/cli/commands/app/ios/ios.go
@@ -1,7 +1,10 @@
 package ios
 
 import (
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/TouchBistro/goutils/fatal"
 	"github.com/TouchBistro/tb/cli"
+	"github.com/TouchBistro/tb/engine"
 	"github.com/spf13/cobra"
 )
 
@@ -13,4 +16,36 @@ func NewiOSCommand(c *cli.Container) *cobra.Command {
 	}
 	iosCmd.AddCommand(newLogsCommand(c), newRunCommand(c))
 	return iosCmd
+}
+
+func resolveDeviceName(c *cli.Container, appName, iosVersion, deviceName string) (resolvediOSVersion, resolvedDeviceName string, err error) {
+	if deviceName != "" {
+		// deviceName was provided so use that, even if iosVersion is empty it will be resolved later.
+		return iosVersion, deviceName, nil
+	}
+	// Prompt the user to select a device
+	var deviceNames []string
+	deviceNames, resolvediOSVersion, err = c.Engine.AppiOSListDevices(c.Ctx, engine.AppiOSListDevicesOptions{
+		AppName:    appName,
+		IOSVersion: iosVersion,
+	})
+	if err != nil {
+		return "", "", &fatal.Error{
+			Msg: "Failed to get list of iOS devices",
+			Err: err,
+		}
+	}
+
+	prompt := &survey.Select{
+		Message: "Select iOS simulator device to use:",
+		Options: deviceNames,
+	}
+	var selected string
+	if err := survey.AskOne(prompt, &selected); err != nil {
+		return "", "", &fatal.Error{
+			Msg: "Failed to prompt for iOS device",
+			Err: err,
+		}
+	}
+	return resolvediOSVersion, selected, nil
 }

--- a/cli/commands/app/ios/logs.go
+++ b/cli/commands/app/ios/logs.go
@@ -33,15 +33,21 @@ Displays the last 10 logs in the default iOS simulator:
 
 Displays the last 20 logs in an iOS 12.4 iPad Air 2 simulator:
 
-	tb app logs --number 20 --ios-version 12.4 --device iPad Air 2`,
+	tb app logs --number 20 --ios-version 12.4 --device "iPad Air 2"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			iosVersion, deviceName, err := resolveDeviceName(c, "", opts.iosVersion, opts.deviceName)
+			if err != nil {
+				return err
+			}
+
 			logsPath, err := c.Engine.AppiOSLogsPath(c.Ctx, engine.AppiOSLogsPathOptions{
-				IOSVersion: opts.iosVersion,
-				DeviceName: opts.deviceName,
+				IOSVersion: iosVersion,
+				DeviceName: deviceName,
 			})
 			if err != nil {
 				return err
 			}
+
 			c.Tracker.Info("Attaching to simulator logs")
 			tail := exec.CommandContext(c.Ctx, "tail", "-f", "-n", opts.numberOfLines, logsPath)
 			tail.Stdout = os.Stdout

--- a/cli/commands/app/ios/logs.go
+++ b/cli/commands/app/ios/logs.go
@@ -57,7 +57,8 @@ Displays the last 20 logs in an iOS 12.4 iPad Air 2 simulator:
 				if errors.As(err, &exitErr) {
 					return &fatal.Error{Code: exitErr.ExitCode()}
 				}
-				return &fatal.Error{Err: err}
+				// Error isn't from tail, some other error occurred while trying to run it.
+				return &fatal.Error{Msg: "Failed to view simulator logs", Err: err}
 			}
 			return nil
 		},

--- a/cli/commands/app/ios/run.go
+++ b/cli/commands/app/ios/run.go
@@ -30,12 +30,17 @@ Run the current master build of TouchBistro in the default iOS Simulator:
 
 Run the build for specific branch in an iOS 12.3 iPad Air 2 simulator:
 
-	tb app ios run TouchBistro --ios-version 12.3 --device iPad Air 2 --branch task/pay-631/fix-thing`,
+	tb app ios run TouchBistro --ios-version 12.3 --device "iPad Air 2" --branch task/pay-631/fix-thing`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appName := args[0]
-			err := c.Engine.AppiOSRun(c.Ctx, appName, engine.AppiOSRunOptions{
-				IOSVersion: opts.iosVersion,
-				DeviceName: opts.deviceName,
+			iosVersion, deviceName, err := resolveDeviceName(c, appName, opts.iosVersion, opts.deviceName)
+			if err != nil {
+				return err
+			}
+
+			err = c.Engine.AppiOSRun(c.Ctx, appName, engine.AppiOSRunOptions{
+				IOSVersion: iosVersion,
+				DeviceName: deviceName,
 				DataPath:   opts.dataPath,
 				Branch:     opts.branch,
 			})

--- a/cli/commands/nuke.go
+++ b/cli/commands/nuke.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os"
 
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/TouchBistro/goutils/fatal"
 	"github.com/TouchBistro/tb/cli"
 	"github.com/TouchBistro/tb/engine"
@@ -31,18 +32,25 @@ func newNukeCommand(c *cli.Container) *cobra.Command {
 docker containers, docker images, docker networks, docker volumes, cloned service git repos,
 downloaded iOS apps, downloaded desktop apps, cloned registries.
 
-Flags must be provided to specify which resources to remove. The special --all flag causes all
-resources to be removed, and also removes the directory where tb stores data.
+By default, nuke will prompt the user to select which resources to remove.
+Flags may be provided to bypass the prompt and specify which resources to remove.
+The special --all flag causes all resources to be removed, and also removes the
+directory where tb stores data.
 
-If any docker resources are specified to be removed, any running service containers will first be stopped.
+If any docker resources are specified to be removed, any running service containers will
+first be stopped and all service containers will be removed.
 
 tb nuke will not remove any docker resources that are not managed by tb.
 
 Examples:
 
-Remove all docker containers and images:
+Prompt to select resources to remove:
 
-	tb nuke --containers --images
+	tb nuke
+
+Remove all docker images and volumes (will also remove docker containers):
+
+	tb nuke --images --volumes
 
 Remove all downloaded iOS and desktop apps:
 
@@ -52,11 +60,45 @@ Remove everything (completely wipe all tb data):
 
 	tb nuke --all`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// If no flags were provided do an interactive prompt and ask the user
+			// what they would like to remove.
 			if !opts.nukeContainers && !opts.nukeImages && !opts.nukeVolumes &&
 				!opts.nukeNetworks && !opts.nukeRepos && !opts.nukeDesktopApps &&
 				!opts.nukeIOSBuilds && !opts.nukeRegistries && !opts.nukeAll {
-				return &fatal.Error{
-					Msg: "Error: Must specify what to nuke. Try tb nuke --help to see all the options.",
+				choices := []struct {
+					name        string
+					optionField *bool
+				}{
+					{"Containers", &opts.nukeContainers},
+					{"Images", &opts.nukeImages},
+					{"Volumes", &opts.nukeVolumes},
+					{"Networks", &opts.nukeNetworks},
+					{"Repos", &opts.nukeRepos},
+					{"Desktop Apps", &opts.nukeDesktopApps},
+					{"iOS Apps", &opts.nukeIOSBuilds},
+					{"Registries", &opts.nukeRegistries},
+				}
+				var promptOptions []string
+				for _, c := range choices {
+					promptOptions = append(promptOptions, c.name)
+				}
+
+				prompt := &survey.MultiSelect{
+					Message:  "Choose what to remove:",
+					Options:  promptOptions,
+					PageSize: len(promptOptions), // Make sure all choices are rendered without pagination
+				}
+				var selected []int
+				// Use required validator to enforce that at least one option is selected.
+				err := survey.AskOne(prompt, &selected, survey.WithValidator(survey.Required))
+				if err != nil {
+					return &fatal.Error{
+						Msg: "Failed to prompt for what to remove",
+						Err: err,
+					}
+				}
+				for _, si := range selected {
+					*choices[si].optionField = true
 				}
 			}
 			err := c.Engine.Nuke(c.Ctx, engine.NukeOptions{
@@ -92,9 +134,9 @@ Remove everything (completely wipe all tb data):
 
 	flags := nukeCmd.Flags()
 	flags.BoolVar(&opts.nukeContainers, "containers", false, "Remove all service containers")
-	flags.BoolVar(&opts.nukeImages, "images", false, "Remove all images")
-	flags.BoolVar(&opts.nukeVolumes, "volumes", false, "Remove all volumes")
-	flags.BoolVar(&opts.nukeNetworks, "networks", false, "Remove all networks")
+	flags.BoolVar(&opts.nukeImages, "images", false, "Remove all images (implies --containers)")
+	flags.BoolVar(&opts.nukeVolumes, "volumes", false, "Remove all volumes (implies --containers)")
+	flags.BoolVar(&opts.nukeNetworks, "networks", false, "Remove all networks (implies --containers)")
 	flags.BoolVar(&opts.nukeRepos, "repos", false, "Remove all service git repos")
 	flags.BoolVar(&opts.nukeDesktopApps, "desktop", false, "Remove all downloaded desktop app builds")
 	flags.BoolVar(&opts.nukeIOSBuilds, "ios", false, "Remove all downloaded iOS app builds")

--- a/engine/app_test.go
+++ b/engine/app_test.go
@@ -1,0 +1,116 @@
+package engine_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/TouchBistro/tb/engine"
+	"github.com/TouchBistro/tb/integrations/simulator"
+	"github.com/TouchBistro/tb/resource/app"
+	"github.com/matryer/is"
+)
+
+func TestAppiOSListDevices(t *testing.T) {
+	tests := []struct {
+		name           string
+		opts           engine.AppiOSListDevicesOptions
+		wantDevices    []string
+		wantiOSVersion string
+	}{
+		{
+			name:           "no options",
+			wantDevices:    []string{"iPhone 11", "iPhone 11 Pro", "iPad Pro (9.7-inch)", "iPad (7th generation)"},
+			wantiOSVersion: "13.5",
+		},
+		{
+			name: "app with any device type",
+			opts: engine.AppiOSListDevicesOptions{
+				AppName: "UIKitDemo",
+			},
+			wantDevices:    []string{"iPhone 11", "iPhone 11 Pro", "iPad Pro (9.7-inch)", "iPad (7th generation)"},
+			wantiOSVersion: "13.5",
+		},
+		{
+			name: "app with ipad only",
+			opts: engine.AppiOSListDevicesOptions{
+				AppName:    "TouchBistro",
+				IOSVersion: "13.5",
+			},
+			wantDevices:    []string{"iPad Pro (9.7-inch)", "iPad (7th generation)"},
+			wantiOSVersion: "13.5",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ac := newAppCollection(t, []app.App{
+				{
+					BundleID: "com.touchbistro.TouchBistro",
+					RunsOn:   "iPad",
+					Branch:   "master",
+					GitRepo:  "TouchBistro/tb-pos",
+					EnvVars: map[string]string{
+						"debug.autoAcceptTOS": "true",
+					},
+					Storage: app.Storage{
+						Provider: "s3",
+						Bucket:   "tb-ios-builds",
+					},
+					Name:         "TouchBistro",
+					RegistryName: "TouchBistro/tb-registry",
+				},
+				{
+					BundleID: "com.touchbistro.UIKitDemo",
+					Branch:   "master",
+					GitRepo:  "TouchBistro/TBUIKit",
+					Storage: app.Storage{
+						Provider: "s3",
+						Bucket:   "tb-ios-builds",
+					},
+					Name:         "UIKitDemo",
+					RegistryName: "TouchBistro/tb-registry",
+				},
+			})
+			e := newEngine(t, engine.Options{
+				IOSApps:    ac,
+				DeviceList: newDeviceList(t),
+			})
+
+			ctx := context.Background()
+			deviceNames, iosVersion, err := e.AppiOSListDevices(ctx, tt.opts)
+			is := is.New(t)
+			is.NoErr(err)
+
+			is.Equal(deviceNames, tt.wantDevices)
+			is.Equal(iosVersion, tt.wantiOSVersion)
+		})
+	}
+}
+
+func newAppCollection(t *testing.T, apps []app.App) *app.Collection {
+	t.Helper()
+	var ac app.Collection
+	for _, a := range apps {
+		if err := ac.Set(a); err != nil {
+			t.Fatalf("failed to add app %s to collection: %v", a.FullName(), err)
+		}
+	}
+	return &ac
+}
+
+func newDeviceList(t *testing.T) simulator.DeviceList {
+	t.Helper()
+	// DISCUSS(@cszatmary): Does this make sense to do?
+	// I'd prefer to share the same test data but it feels wrong
+	// for this package to be reaching into the simulator package.
+	data, err := os.ReadFile(filepath.FromSlash("../integrations/simulator/testdata/devices.json"))
+	if err != nil {
+		t.Fatalf("failed to read devices.json: %v", err)
+	}
+	dl, err := simulator.ParseDevices(data)
+	if err != nil {
+		t.Fatalf("failed to parse devices: %v", err)
+	}
+	return dl
+}

--- a/engine/service_test.go
+++ b/engine/service_test.go
@@ -346,6 +346,45 @@ func TestNuke(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "remove containers if removing other docker resources",
+			mockAPIClientOpts: docker.MockAPIClientOptions{
+				Containers: []dockertypes.Container{
+					{
+						ID:    "32ce4d8d9c648dd5fce39cf48319da8d55b195513b6fe0cef4a425de9380590c",
+						Names: []string{"touchbistro-tb-registry-postgres"},
+						Labels: map[string]string{
+							docker.ProjectLabel: "tb",
+						},
+						State: docker.ContainerStateRunning,
+					},
+				},
+				Networks: []dockertypes.NetworkResource{
+					{
+						ID:   "872eead77c73055de86c8ca6a17d509937c8e8c747b00a40a8374cec721b70e4",
+						Name: "tb_default",
+						Labels: map[string]string{
+							docker.ProjectLabel: "tb",
+						},
+					},
+				},
+				Volumes: []dockertypes.Volume{
+					{
+						Name: "tb_postgres",
+						Labels: map[string]string{
+							docker.ProjectLabel: "tb",
+						},
+					},
+				},
+			},
+			nukeOpts: engine.NukeOptions{
+				RemoveNetworks: true,
+				RemoveVolumes:  true,
+			},
+			wantContainers: nil,
+			wantNetworks:   nil,
+			wantVolumes:    nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/TouchBistro/tb
 go 1.17
 
 require (
+	github.com/AlecAivazis/survey/v2 v2.3.2
 	github.com/TouchBistro/goutils v0.3.0
 	github.com/aws/aws-sdk-go-v2 v1.11.2
 	github.com/aws/aws-sdk-go-v2/config v1.11.0
@@ -46,8 +47,12 @@ require (
 	github.com/gorilla/mux v1.7.2 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/moby/term v0.0.0-20200312100748-672ec06f55cd // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
@@ -62,6 +67,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
+	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
 	google.golang.org/grpc v1.42.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/AlecAivazis/survey/v2 v2.3.2 h1:TqTB+aDDCLYhf9/bD2TwSO8u8jDSmMUd2SUVO4gCnU8=
+github.com/AlecAivazis/survey/v2 v2.3.2/go.mod h1:TH2kPCDU3Kqq7pLbnCWwZXDBjnhZtmsCle5EiYDJ2fg=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -83,14 +85,12 @@ github.com/Microsoft/hcsshim v0.8.23/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
+github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
+github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
-github.com/TouchBistro/goutils v0.2.1-0.20220117001054-efef9eb368e2 h1:ezxe2++GMN4vz/Y2nTIT6fsAAUFLeTnMrK4GKOjYQuA=
-github.com/TouchBistro/goutils v0.2.1-0.20220117001054-efef9eb368e2/go.mod h1:Z4vmIj97FCumPsWY9w/h+KgTglEUDJjTySWP7RgUIJ4=
-github.com/TouchBistro/goutils v0.2.1-0.20220120212605-0560d8656f2a h1:AlOxfeaTXFu0rqyblS329i0TFMiwsDk610ssa5G0nUM=
-github.com/TouchBistro/goutils v0.2.1-0.20220120212605-0560d8656f2a/go.mod h1:Z4vmIj97FCumPsWY9w/h+KgTglEUDJjTySWP7RgUIJ4=
 github.com/TouchBistro/goutils v0.3.0 h1:k1LNPCJbcC/tkbG14nplU9OxSMSzjLCcgHMn8NIVDqQ=
 github.com/TouchBistro/goutils v0.3.0/go.mod h1:Z4vmIj97FCumPsWY9w/h+KgTglEUDJjTySWP7RgUIJ4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -519,6 +519,8 @@ github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
+github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174 h1:WlZsjVhE8Af9IcZDGgJGQpNflI3+MJSBhsgT5PCtzBQ=
+github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -548,6 +550,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -563,6 +567,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/pty v1.1.5 h1:hyz3dwM5QLc1Rfoz4FuWJQG5BN7tc6K1MndAUnGpQr4=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -577,9 +583,11 @@ github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHef
 github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
 github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -587,12 +595,15 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
@@ -770,6 +781,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -840,6 +852,7 @@ golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -1067,6 +1080,7 @@ golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d h1:FjkYO/PPp4Wi0EAUOVLxePm7qVW4r4ctbWpURyuOD0E=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/integrations/simulator/device_test.go
+++ b/integrations/simulator/device_test.go
@@ -9,6 +9,134 @@ import (
 	"github.com/matryer/is"
 )
 
+func TestGetDefaultDevice(t *testing.T) {
+	tests := []struct {
+		name        string
+		osVersion   string
+		deviceType  simulator.DeviceType
+		wantDevices []simulator.Device
+	}{
+		{
+			name:       "All devices",
+			osVersion:  "iOS 13.5",
+			deviceType: simulator.DeviceTypeUnspecified,
+			wantDevices: []simulator.Device{
+				{
+					State:       "Shutdown",
+					IsAvailable: true,
+					Name:        "iPhone 11",
+					UDID:        "E199247A-BCBE-431A-B909-16C3A58EFC89",
+					LogPath:     "/Users/admin/Library/Logs/CoreSimulator/E199247A-BCBE-431A-B909-16C3A58EFC89",
+					Type:        simulator.DeviceTypeiPhone,
+				},
+				{
+					State:       "Shutdown",
+					IsAvailable: true,
+					Name:        "iPhone 11 Pro",
+					UDID:        "6BEB23FC-447E-4557-A1C2-AD7919F89728",
+					LogPath:     "/Users/admin/Library/Logs/CoreSimulator/6BEB23FC-447E-4557-A1C2-AD7919F89728",
+					Type:        simulator.DeviceTypeiPhone,
+				},
+				{
+					State:       "Shutdown",
+					IsAvailable: true,
+					Name:        "iPad Pro (9.7-inch)",
+					UDID:        "A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1",
+					LogPath:     "/Users/admin/Library/Logs/CoreSimulator/A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1",
+					Type:        simulator.DeviceTypeiPad,
+				},
+				{
+					State:       "Shutdown",
+					IsAvailable: true,
+					Name:        "iPad (7th generation)",
+					UDID:        "F8D16DB4-8639-4BBA-9E84-0ECCB73F43E0",
+					LogPath:     "/Users/admin/Library/Logs/CoreSimulator/F8D16DB4-8639-4BBA-9E84-0ECCB73F43E0",
+					Type:        simulator.DeviceTypeiPad,
+				},
+			},
+		},
+		{
+			name:       "Only iPads",
+			osVersion:  "iOS 13.5",
+			deviceType: simulator.DeviceTypeiPad,
+			wantDevices: []simulator.Device{
+				{
+					State:       "Shutdown",
+					IsAvailable: true,
+					Name:        "iPad Pro (9.7-inch)",
+					UDID:        "A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1",
+					LogPath:     "/Users/admin/Library/Logs/CoreSimulator/A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1",
+					Type:        simulator.DeviceTypeiPad,
+				},
+				{
+					State:       "Shutdown",
+					IsAvailable: true,
+					Name:        "iPad (7th generation)",
+					UDID:        "F8D16DB4-8639-4BBA-9E84-0ECCB73F43E0",
+					LogPath:     "/Users/admin/Library/Logs/CoreSimulator/F8D16DB4-8639-4BBA-9E84-0ECCB73F43E0",
+					Type:        simulator.DeviceTypeiPad,
+				},
+			},
+		},
+		{
+			name:       "Only iPhones",
+			osVersion:  "iOS 13.5",
+			deviceType: simulator.DeviceTypeiPhone,
+			wantDevices: []simulator.Device{
+				{
+					State:       "Shutdown",
+					IsAvailable: true,
+					Name:        "iPhone 11",
+					UDID:        "E199247A-BCBE-431A-B909-16C3A58EFC89",
+					LogPath:     "/Users/admin/Library/Logs/CoreSimulator/E199247A-BCBE-431A-B909-16C3A58EFC89",
+					Type:        simulator.DeviceTypeiPhone,
+				},
+				{
+					State:       "Shutdown",
+					IsAvailable: true,
+					Name:        "iPhone 11 Pro",
+					UDID:        "6BEB23FC-447E-4557-A1C2-AD7919F89728",
+					LogPath:     "/Users/admin/Library/Logs/CoreSimulator/6BEB23FC-447E-4557-A1C2-AD7919F89728",
+					Type:        simulator.DeviceTypeiPhone,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			is := is.New(t)
+			dl := parseDevices(t)
+			d, err := dl.ListDevices(tt.osVersion, tt.deviceType)
+			is.NoErr(err)
+			is.Equal(d, tt.wantDevices)
+		})
+	}
+}
+
+func TestListDevicesError(t *testing.T) {
+	tests := []struct {
+		name       string
+		osVersion  string
+		deviceType simulator.DeviceType
+		wantErr    error
+	}{
+		{
+			name:       "no OS found",
+			osVersion:  "iOS 12.5",
+			deviceType: simulator.DeviceTypeiPad,
+			wantErr:    simulator.ErrOSNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			is := is.New(t)
+			dl := parseDevices(t)
+			_, err := dl.ListDevices(tt.osVersion, tt.deviceType)
+			is.True(errors.Is(err, tt.wantErr))
+		})
+	}
+}
+
 func TestGetDevice(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -25,6 +153,7 @@ func TestGetDevice(t *testing.T) {
 				IsAvailable: true,
 				Name:        "iPad Pro (9.7-inch)",
 				UDID:        "A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1",
+				LogPath:     "/Users/admin/Library/Logs/CoreSimulator/A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1",
 				Type:        simulator.DeviceTypeiPad,
 			},
 		},
@@ -65,91 +194,6 @@ func TestGetDeviceError(t *testing.T) {
 			is := is.New(t)
 			dl := parseDevices(t)
 			_, err := dl.GetDevice(tt.osVersion, tt.deviceName)
-			is.True(errors.Is(err, tt.wantErr))
-		})
-	}
-}
-
-func TestGetDefaultDevice(t *testing.T) {
-	tests := []struct {
-		name       string
-		osVersion  string
-		deviceType simulator.DeviceType
-		wantDevice simulator.Device
-	}{
-		{
-			name:       "Any device",
-			osVersion:  "iOS 13.5",
-			deviceType: simulator.DeviceTypeUnspecified,
-			wantDevice: simulator.Device{
-				State:       "Shutdown",
-				IsAvailable: true,
-				Name:        "iPhone 8",
-				UDID:        "67D79B13-7D22-4CE4-A15C-0472EE48360D",
-				Type:        simulator.DeviceTypeiPhone,
-			},
-		},
-		{
-			name:       "Only iPad",
-			osVersion:  "iOS 13.5",
-			deviceType: simulator.DeviceTypeiPad,
-			wantDevice: simulator.Device{
-				State:       "Shutdown",
-				IsAvailable: true,
-				Name:        "iPad Pro (9.7-inch)",
-				UDID:        "A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1",
-				Type:        simulator.DeviceTypeiPad,
-			},
-		},
-		{
-			name:       "Only iPhone",
-			osVersion:  "iOS 13.5",
-			deviceType: simulator.DeviceTypeiPhone,
-			wantDevice: simulator.Device{
-				State:       "Shutdown",
-				IsAvailable: true,
-				Name:        "iPhone 8",
-				UDID:        "67D79B13-7D22-4CE4-A15C-0472EE48360D",
-				Type:        simulator.DeviceTypeiPhone,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			is := is.New(t)
-			dl := parseDevices(t)
-			d, err := dl.GetDefaultDevice(tt.osVersion, tt.deviceType)
-			is.NoErr(err)
-			is.Equal(d, tt.wantDevice)
-		})
-	}
-}
-
-func TestGetDefaultDeviceError(t *testing.T) {
-	tests := []struct {
-		name       string
-		osVersion  string
-		deviceType simulator.DeviceType
-		wantErr    error
-	}{
-		{
-			name:       "no OS found",
-			osVersion:  "iOS 12.5",
-			deviceType: simulator.DeviceTypeiPad,
-			wantErr:    simulator.ErrOSNotFound,
-		},
-		{
-			name:       "no device found",
-			osVersion:  "iOS 13.2",
-			deviceType: simulator.DeviceTypeiPad,
-			wantErr:    simulator.ErrDeviceNotFound,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			is := is.New(t)
-			dl := parseDevices(t)
-			_, err := dl.GetDefaultDevice(tt.osVersion, tt.deviceType)
 			is.True(errors.Is(err, tt.wantErr))
 		})
 	}

--- a/integrations/simulator/simulator.go
+++ b/integrations/simulator/simulator.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -34,6 +35,7 @@ type Simulator interface {
 	InstallApp(ctx context.Context, appPath string) error
 	LaunchApp(ctx context.Context, appBundleID string) error
 	GetAppDataPath(ctx context.Context, appBundleID string) (string, error)
+	Setenv(key, value string) error
 }
 
 // simulator implements Simulator using the simctl command.
@@ -85,6 +87,11 @@ func (sim *simulator) GetAppDataPath(ctx context.Context, appBundleID string) (s
 		return "", err
 	}
 	return strings.TrimSpace(buf.String()), nil
+}
+
+func (sim *simulator) Setenv(key, value string) error {
+	// Env vars can be passed to simctl if they are set in the calling environment with a SIMCTL_CHILD_ prefix.
+	return os.Setenv("SIMCTL_CHILD_"+key, value)
 }
 
 func execSimctl(ctx context.Context, op errors.Op, stdout io.Writer, args ...string) error {

--- a/integrations/simulator/testdata/devices.json
+++ b/integrations/simulator/testdata/devices.json
@@ -79,24 +79,6 @@
     ],
     "com.apple.CoreSimulator.SimRuntime.iOS-13-5": [
       {
-        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/67D79B13-7D22-4CE4-A15C-0472EE48360D/data",
-        "logPath": "/Users/admin/Library/Logs/CoreSimulator/67D79B13-7D22-4CE4-A15C-0472EE48360D",
-        "udid": "67D79B13-7D22-4CE4-A15C-0472EE48360D",
-        "isAvailable": true,
-        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-8",
-        "state": "Shutdown",
-        "name": "iPhone 8"
-      },
-      {
-        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/5EEE5EFF-A600-4623-BD14-386124A03657/data",
-        "logPath": "/Users/admin/Library/Logs/CoreSimulator/5EEE5EFF-A600-4623-BD14-386124A03657",
-        "udid": "5EEE5EFF-A600-4623-BD14-386124A03657",
-        "isAvailable": true,
-        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-8-Plus",
-        "state": "Shutdown",
-        "name": "iPhone 8 Plus"
-      },
-      {
         "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/E199247A-BCBE-431A-B909-16C3A58EFC89/data",
         "logPath": "/Users/admin/Library/Logs/CoreSimulator/E199247A-BCBE-431A-B909-16C3A58EFC89",
         "udid": "E199247A-BCBE-431A-B909-16C3A58EFC89",
@@ -115,24 +97,6 @@
         "name": "iPhone 11 Pro"
       },
       {
-        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/6838393D-132F-47AF-984D-CC0F9C8ED33F/data",
-        "logPath": "/Users/admin/Library/Logs/CoreSimulator/6838393D-132F-47AF-984D-CC0F9C8ED33F",
-        "udid": "6838393D-132F-47AF-984D-CC0F9C8ED33F",
-        "isAvailable": true,
-        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro-Max",
-        "state": "Shutdown",
-        "name": "iPhone 11 Pro Max"
-      },
-      {
-        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/CD3BD8C5-819C-4B12-9310-E312A42F3BBC/data",
-        "logPath": "/Users/admin/Library/Logs/CoreSimulator/CD3BD8C5-819C-4B12-9310-E312A42F3BBC",
-        "udid": "CD3BD8C5-819C-4B12-9310-E312A42F3BBC",
-        "isAvailable": true,
-        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-SE--2nd-generation-",
-        "state": "Shutdown",
-        "name": "iPhone SE (2nd generation)"
-      },
-      {
         "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1/data",
         "logPath": "/Users/admin/Library/Logs/CoreSimulator/A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1",
         "udid": "A01ADC2E-6AAE-401C-A5B4-5CC5B165E8A1",
@@ -149,33 +113,6 @@
         "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPad--7th-generation-",
         "state": "Shutdown",
         "name": "iPad (7th generation)"
-      },
-      {
-        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/7DE96DB3-36DB-453F-88A2-92BD79F8168D/data",
-        "logPath": "/Users/admin/Library/Logs/CoreSimulator/7DE96DB3-36DB-453F-88A2-92BD79F8168D",
-        "udid": "7DE96DB3-36DB-453F-88A2-92BD79F8168D",
-        "isAvailable": true,
-        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--11-inch---2nd-generation-",
-        "state": "Shutdown",
-        "name": "iPad Pro (11-inch) (2nd generation)"
-      },
-      {
-        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/E93D9611-7AD2-4300-9245-3C7F73EA64A9/data",
-        "logPath": "/Users/admin/Library/Logs/CoreSimulator/E93D9611-7AD2-4300-9245-3C7F73EA64A9",
-        "udid": "E93D9611-7AD2-4300-9245-3C7F73EA64A9",
-        "isAvailable": true,
-        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---4th-generation-",
-        "state": "Shutdown",
-        "name": "iPad Pro (12.9-inch) (4th generation)"
-      },
-      {
-        "dataPath": "/Users/admin/Library/Developer/CoreSimulator/Devices/E569908B-F992-44D8-843C-205B7070AD9E/data",
-        "logPath": "/Users/admin/Library/Logs/CoreSimulator/E569908B-F992-44D8-843C-205B7070AD9E",
-        "udid": "E569908B-F992-44D8-843C-205B7070AD9E",
-        "isAvailable": true,
-        "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPad-Air--3rd-generation-",
-        "state": "Booted",
-        "name": "iPad Air (3rd generation)"
       }
     ],
     "com.apple.CoreSimulator.SimRuntime.watchOS-5-2": [],

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 
+	surveyterm "github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/TouchBistro/goutils/fatal"
 	"github.com/TouchBistro/tb/cli"
 	"github.com/TouchBistro/tb/cli/commands"
@@ -30,52 +31,61 @@ func main() {
 	var c cli.Container
 	rootCmd := commands.NewRootCommand(&c, version)
 	err := rootCmd.ExecuteContext(ctx)
+	fatalErr, removeLogfile := mapError(ctx, err)
 
 	// Close log file and remove it if there was no error.
 	// Ignore the error since there is nothing we can do about it.
 	// Also, temp files are automatically cleaned up on reboots
 	// so it's not a big deal.
-	_ = c.Logger.Cleanup(err == nil)
+	_ = c.Logger.Cleanup(removeLogfile)
 	if err == nil {
 		return
 	}
 
-	// Handle error
-	var fatalErr *fatal.Error
+	exiter := &fatal.Exiter{
+		PrintDetailed: c.Verbose,
+		ExitFunc: func(code int) {
+			// Tell user where log file is for further troubleshooting.
+			// Skip if code is 130 since that means the user aborted the
+			// program with control-C.
+			if name := c.Logger.Filename(); name != "" && code != 130 {
+				fmt.Fprintf(os.Stderr, "\n👉 Logs are available at: %s 👈\n", name)
+			}
+			os.Exit(code)
+		},
+	}
+	exiter.PrintAndExit(fatalErr)
+}
+
+func mapError(ctx context.Context, err error) (fatalErr *fatal.Error, removeLogfile bool) {
 	switch {
+	case err == nil:
+		return nil, true
+	// Handle special error cases first
+	case errors.Is(err, context.Canceled) || errors.Is(err, surveyterm.InterruptErr):
+		return &fatal.Error{Code: 130, Msg: "\nOperation cancelled"}, true
+	// See if the context was cancelled. This is important for subprocesses created by os/exec
+	// since exit codes don't propagate if the subprocess was terminated with a signal.
+	case errors.Is(ctx.Err(), context.Canceled):
+		return &fatal.Error{Code: 130}, true
+	// See if already a fatal.Error
 	case errors.As(err, &fatalErr):
-		// Nothing to do, since fatalErr is now populated
-	case errors.Is(err, context.Canceled):
-		fatalErr = &fatal.Error{
-			Code: 130,
-			Msg:  "\nOperation cancelled",
-		}
-	case
-		errors.Is(err, resource.ErrNotFound):
-		fatalErr = &fatal.Error{
-			Msg: "Try running `tb list` to see available services",
-			Err: err,
-		}
 	default:
-		// TODO(@cszatmary): We can check if errors.Error and use the Kind
-		// to add custom messages to try and help the user.
-		// We should also add sepecific error codes based on Kind.
-		fatalErr = &fatal.Error{Err: err}
+		return &fatal.Error{Err: err}, false
+	}
+	// If no underlying error, just return as is.
+	if fatalErr.Err == nil {
+		return
 	}
 
-	// Print the error ourselves instead of letting fatal do it since we want
-	// to do some additional stuff after before exiting.
-	if fatalErr.Msg != "" || fatalErr.Err != nil {
-		if c.Verbose {
-			fmt.Fprintf(os.Stderr, "%+v\n", fatalErr)
-		} else {
-			fmt.Fprintf(os.Stderr, "%v\n", fatalErr)
-		}
+	// Check for specific errors and improve the message for a better user experience.
+	// TODO(@cszatmary): We can check if errors.Error and use the Kind
+	// to add custom messages to try and help the user.
+	// We should also add specific error codes based on Kind.
+	switch {
+	case errors.Is(fatalErr.Err, resource.ErrNotFound):
+		// TODO(@cszatmary): Should we have a custom exit code?
+		fatalErr.Msg = "Try running `tb list` to see available services"
 	}
-
-	// Tell user where log file is for further troubleshooting.
-	if name := c.Logger.Filename(); name != "" {
-		fmt.Fprintf(os.Stderr, "\n👉 Logs are available at: %s 👈\n", name)
-	}
-	fatal.Exit(fatalErr)
+	return
 }


### PR DESCRIPTION
* `tb nuke` now works with no flags and will prompt the user to select one or more things to remove.
![image](https://user-images.githubusercontent.com/22629536/153933534-ce6e5ed1-9fd7-49aa-8049-58cae7e97fd2.png)
* `tb app ios run` and `tb app ios logs` now prompt the user to select an iOS simulator. Previously it would try to pick a default but this had issues and was confusing for users.
![image](https://user-images.githubusercontent.com/22629536/153933786-9e429eb9-a840-4218-bf30-13b1159bb734.png)
* Nuking images, volumes, or networks now also stops and removes containers. Previously this would break if `tb down` was not run first since these resources cannot be removed when used by containers.
* Fixed some cases where using control-C to terminate the program would not have the correct exit code and would display the logfile path.