### PR TITLE
fix/INT-5482: Allow string interpolation for the 'endpoints' property in docker compose

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -387,6 +387,9 @@ func readServices(op errors.Op, r Registry, opts readServicesOptions) (serviceGl
 		for i, volume := range s.Remote.Volumes {
 			s.Remote.Volumes[i].Value = ve.expand(volume.Value, "remote.volumes")
 		}
+		for i, value := range s.Entrypoint {
+			s.Entrypoint[i] = ve.expand(value, "entrypointValue")
+		}
 
 		// Report unknown vars as an error if in strict mode
 		if len(ve.errMsgs) > 0 && opts.strict {


### PR DESCRIPTION
Passing in interpolated variables doesn't work for the `entrypoints` property in `tb-registry`'s services.yml file. This PR is to expand all the values passed in the `entrypoints` array.