### PR TITLE
fix go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/TouchBistro/tb
 
 go 1.21
 
-toolchain go1.21.0
-
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/TouchBistro/goutils v0.5.0


### PR DESCRIPTION
deployment failed: https://shipit.touchbistro.net/touchbistro/tb/production/deploys/29791

asked chatgpt and it said that `toolchain` is an invalid directive and should be removed from `go.mod`