### PR TITLE
fix deprecated brews.tap in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,7 @@ changelog:
     - '^test:'
 
 brews:
-  - tap:
+  - repository:
       owner: TouchBistro
       name: homebrew-tap
     commit_author:


### PR DESCRIPTION
https://goreleaser.com/deprecations/#brewstap