### PR TITLE
task: (ACC-2546) use npm read token instead of the publishing one

### DIFF
--- a/docs/registries.md
+++ b/docs/registries.md
@@ -3,6 +3,7 @@
 A registry is a GitHub repo that provides configuration of apps, playlists, and services that can be run with `tb`.
 
 A registry has the following directory structure:
+
 ```
 apps.yml
 playlists.yml
@@ -17,12 +18,14 @@ All files are optional. A `static` directory can be present with files that can 
 To use a registry add it to the `registries` section of your `~/.tbrc.yml`. Registries are always of the form `org/repo`.
 
 Ex:
+
 ```yaml
 registries:
   - name: TouchBistro/tb-registry
 ```
 
 You can also add a registry by running the following:
+
 ```
 tb registry add <name>
 ```
@@ -30,11 +33,13 @@ tb registry add <name>
 All services, playlists, and apps in a registry are scoped by the name of that registry to ensure they are globally unique. If a service, playlist or app name is unique, however you can use this name directly in commands and `tb` will figure out which service you are referring to.
 
 For example if there is a service named `postgres` in the registry `TouchBistro/tb-registry`, you can run it with the following command:
+
 ```
 tb up -s TouchBistro/tb-registry/postgres
 ```
 
 If this is the only service named `postgres` that `tb` knows about, the following also works:
+
 ```
 tb up -s postgres
 ```
@@ -44,11 +49,13 @@ tb up -s postgres
 ### Testing changes to a registry
 
 To have `tb` validate your changes to make sure it is able load the configs run the following:
+
 ```
 tb registry validate <path>
 ```
 
 For example if you are currently in the root directory of your registry you would run:
+
 ```
 tb registry validate .
 ```
@@ -57,6 +64,7 @@ For more robust testing you can temporarily tell `tb` to use your local version 
 To do that add a `localPath` field to the registry and set it to the path of the registry on your machine in your `~/.tbrc.yml`.
 
 Ex:
+
 ```yaml
 registries:
   - name: TouchBistro/tb-registry
@@ -68,36 +76,40 @@ registries:
 Apps are configured in `apps.yml`.
 
 The schema of the file is:
+
 ```yaml
 iosApps: map
 desktopApps: map
 ```
 
 The schema of an iOS app is:
+
 ```yaml
 <name>:
-  bundleID: string             # The bundle ID of the iOS app
-  branch: string               # The base branch of the repo, ex: master
-  repo: string                 # The repo name on GitHub, format: org/repo
+  bundleID: string # The bundle ID of the iOS app
+  branch: string # The base branch of the repo, ex: master
+  repo: string # The repo name on GitHub, format: org/repo
   envVars: map<string, string> # Env vars to set for the app
-  runsOn: all | ipad | iphone  # What type of device the app can run on
+  runsOn: all | ipad | iphone # What type of device the app can run on
   storage:
-    provider: s3   # The storage provider to use
+    provider: s3 # The storage provider to use
     bucket: string # The name of the bucket the builds are stored in
 ```
 
 The schema of a desktop app is:
+
 ```yaml
 <name>:
-  branch: string               # The base branch of the repo, ex: master
-  repo: string                 # The repo name on GitHub, format: org/repo
+  branch: string # The base branch of the repo, ex: master
+  repo: string # The repo name on GitHub, format: org/repo
   envVars: map<string, string> # Env vars to set for the app
   storage:
-    provider: s3   # The storage provider to use
+    provider: s3 # The storage provider to use
     bucket: string # The name of the bucket the builds are stored in
 ```
 
 #### Specifying Device Types for iOS Apps
+
 Some iOS apps can only run on certain device types, for example only on iPad. You can specify this using `runsOn` field. Valid values are `all`, `ipad`, and `iphone`. This field is case-insensitive so `ipad` and `iPad` are equivalent.
 
 If `runsOn` is not specified it is assumed to be `all`.
@@ -107,10 +119,11 @@ If `runsOn` is not specified it is assumed to be `all`.
 Services are configured in `services.yml`.
 
 The schema of the file is:
+
 ```yaml
 global:
-  baseImages: string[]           # A list of docker images to pull before building containers.
-  loginStrategies: string[]      # A list of login strategies to run, valid values: ecr, npm
+  baseImages: string[] # A list of docker images to pull before building containers.
+  loginStrategies: string[] # A list of login strategies to run, valid values: ecr, npm
   variables: map<string, string> # Variables that can be used in service definitions
 services: map<string, Service> # The services that can be run
 ```
@@ -120,8 +133,9 @@ services: map<string, Service> # The services that can be run
 `tb` can ensure you are logged in to certain 3rd party services before running your services.
 
 The following login strategies are avaible:
-* `ecr`: Performs `docker login` to AWS ECR images can be pulled from there. This strategy assumes you have your AWS account configured locally using the `aws cli`.
-* `npm`: Enures you are logged in to the NPM registry and have the environment variable `NPM_TOKEN` set.
+
+- `ecr`: Performs `docker login` to AWS ECR images can be pulled from there. This strategy assumes you have your AWS account configured locally using the `aws cli`.
+- `npm`: Enures you are logged in to the NPM registry and have the environment variable `NPM_READ_TOKEN` set.
 
 We welcome PRs for additional login strategies if these don't meet your needs.
 
@@ -130,33 +144,35 @@ We welcome PRs for additional login strategies if these don't meet your needs.
 To add a new service add an entry to the `services` field in `services.yml`.
 
 The schema is as follows:
+
 ```yaml
 <service-name>:
-  dependencies: string[]       # Any services that this service requires to run (eg postgres)
-  entrypoint: string           # Custom Docker entrypoint
-  envFile: string              # Path to env file
+  dependencies: string[] # Any services that this service requires to run (eg postgres)
+  entrypoint: string # Custom Docker entrypoint
+  envFile: string # Path to env file
   envVars: map<string, string> # Env vars to set for the services
-  mode: remote | build         # What mode to use: remote or build
-  ports: string[]              # List of ports to expose
-  preRun: string               # Script to run before starting the service, e.g. 'yarn db:prepare' to run db migrations
+  mode: remote | build # What mode to use: remote or build
+  ports: string[] # List of ports to expose
+  preRun: string # Script to run before starting the service, e.g. 'yarn db:prepare' to run db migrations
   repo:
     name: string # The repo name on GitHub, format: org/repo
   build:
     args: map<string, string> # List of args to pass to docker build
-    command: string           # Command to run when container starts
-    dockerfilePath: string    # Path to the Dockerfile
-    target: string            # Target to build in a multi-stage build
-    volumes:                  # List of docker volumes to create
-      - value: string  # The volume to create
+    command: string # Command to run when container starts
+    dockerfilePath: string # Path to the Dockerfile
+    target: string # Target to build in a multi-stage build
+    volumes: # List of docker volumes to create
+      - value: string # The volume to create
         named: boolean # Whether or not to create a named volume
   remote:
-    command: string  # Command to run when the container starts
-    image: string    # The image name or a valid URI pointing to a remote docker registry.
-    tag: string      # The the image tag to use (ex: master)
-    volumes:         # List of docker volumes to create
-      - value: string  # The volume to create
+    command: string # Command to run when the container starts
+    image: string # The image name or a valid URI pointing to a remote docker registry.
+    tag: string # The the image tag to use (ex: master)
+    volumes: # List of docker volumes to create
+      - value: string # The volume to create
         named: boolean # Whether or not to create a named volume
 ```
+
 At least one of `build` or `remote` are required. `build` is only required if the service can be built locally with `docker build`, `remote` is only required if the service can be pulled from a remote registry with `docker pull`.
 
 Any unneeded fields can be omitted.
@@ -164,33 +180,38 @@ Any unneeded fields can be omitted.
 #### Variable Expansion
 
 Variable expansion is supported by the following fields in a service:
-* `dependencies`
-* `envFile`
-* `envVars`
-* `build.dockerfilePath`
-* `build.volumes.value`
-* `remote.image`
-* `remote.volumes.value`
+
+- `dependencies`
+- `envFile`
+- `envVars`
+- `build.dockerfilePath`
+- `build.volumes.value`
+- `remote.image`
+- `remote.volumes.value`
 
 Variable expansion is done by placing the variable name inside `${}`.
 Ex:
+
 ```yml
 envFile: ${path}/.env
 ```
 
 There are two types are variables that can be used:
+
 1. User defined variables. These are variables set in the `global.variables` field of `services.yml`.
 2. Builtin variables. These are variables provided by `tb` and are automatically set when `services.yml` is read. Builtin variables are prefixed with `@` to distinguish them from user defined variables.
 
 `tb` provides the following builtin variables:
-* `@ROOTPATH`: The path to `tb`'s root directory, i.e. `~/.tb`.
-* `@STATICPATH`: The path to your registry's `static` directory. Use this variable to reference static files in your registry.
-* `@REPOPATH`: The path to the current service's cloned git repo. This is set for each service.
+
+- `@ROOTPATH`: The path to `tb`'s root directory, i.e. `~/.tb`.
+- `@STATICPATH`: The path to your registry's `static` directory. Use this variable to reference static files in your registry.
+- `@REPOPATH`: The path to the current service's cloned git repo. This is set for each service.
 
 Additionally `tb` will also create a builtin variable that is the name of each service. This variable can be used to reference the containers of other services for fields like `dependencies`. This is useful because the resulting container name will not be the name of your service directly.
 
 Ex:
 If you have a service named `postgres` and need it as a dependency for another service you could do:
+
 ```yaml
 dependencies:
   - ${@postgres}
@@ -201,11 +222,13 @@ dependencies:
 If you required the literal variable syntax and don't want `tb` to expand it, prefix the variable name with `@env:`. `tb` will strip this prefix and leave the variable expansion syntax.
 
 Ex:
+
 ```yaml
 envPath: ${@env:HOME}/tmp
 ```
 
 `tb` will turn this into:
+
 ```yaml
 envPath: ${HOME}/tmp
 ```
@@ -217,11 +240,13 @@ A playlist is a collection of services that can be run with `tb up`.
 Playlists are configured by adding entries to `playlists.yml`.
 
 The schema is as follows:
+
 ```yaml
 <playlist-name>:
   extends: string # A playlist to extend, i.e. add the services from that playlist to this playlist
   services: string[] # A list of services in the playlist
 ```
+
 The `extends` field is optional.
 
 All services listed in a playlist are assumed to exist in the same registry. It is not possible to use services from a different registry in a playlist.

--- a/integrations/login/npm.go
+++ b/integrations/login/npm.go
@@ -21,7 +21,7 @@ func (npmStrategy) Name() string {
 
 func (npmStrategy) Login(ctx context.Context) error {
 	const op = errors.Op("login.npmStrategy.Login")
-	const npmToken = "NPM_TOKEN"
+	const npmToken = "NPM_READ_TOKEN"
 	tracker := progress.TrackerFromContext(ctx)
 	tracker.Debugf("Checking if env var %s is set...", npmToken)
 	if os.Getenv(npmToken) != "" {
@@ -63,7 +63,7 @@ func (npmStrategy) Login(ctx context.Context) error {
 	}
 
 	tracker.Debugf("Found authToken. Setting env var %s...", npmToken)
-	// Set the NPM_TOKEN as an env var. This way any child processes run will inherit this env var
+	// Set the NPM_READ_TOKEN as an env var. This way any child processes run will inherit this env var
 	// meaning when we run docker build it should have access to it
 	// matches[0] is the full match
 	os.Setenv(npmToken, string(matches[1]))

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -93,8 +93,8 @@ func TestReadRegistries(t *testing.T) {
 		},
 		Build: service.Build{
 			Args: map[string]string{
-				"NODE_ENV":  "development",
-				"NPM_TOKEN": "$NPM_TOKEN",
+				"NODE_ENV":       "development",
+				"NPM_READ_TOKEN": "$NPM_READ_TOKEN",
 			},
 			Command:        "yarn start",
 			DockerfilePath: "/home/test/.tb/repos/TouchBistro/venue-core-service",

--- a/registry/testdata/invalid-registry-1/services.yml
+++ b/registry/testdata/invalid-registry-1/services.yml
@@ -5,7 +5,7 @@ services:
       POSTGRES_PASSWORD: localdev
     mode: build
     ports:
-      - '5432:5432'
+      - "5432:5432"
   venue-core-service:
     dependencies:
       - ${@postgres}
@@ -15,14 +15,14 @@ services:
       DB_HOST: ${@postgres}
     mode: local
     ports:
-      - '9000:8080'
+      - "9000:8080"
     preRun: yarn db:prepare
     repo:
       name: TouchBistro/venue-core-service
     build:
       args:
         NODE_ENV: development
-        NPM_TOKEN: $NPM_TOKEN
+        NPM_READ_TOKEN: $NPM_READ_TOKEN
       command: yarn start
       dockerfilePath: ${@REPOPATH}
       target: dev
@@ -42,7 +42,7 @@ services:
       POSTGRES_HOST: ${@postgres}
     mode: local
     ports:
-      - '9000:8000'
+      - "9000:8000"
     preRun: yarn db:prepare:dev
     repo:
       name: ExampleZone/venue-example-service

--- a/registry/testdata/registry-1/services.yml
+++ b/registry/testdata/registry-1/services.yml
@@ -15,7 +15,7 @@ services:
       POSTGRES_PASSWORD: localdev
     mode: remote
     ports:
-      - '5432:5432'
+      - "5432:5432"
     remote:
       image: postgres
       tag: 10.6-alpine
@@ -31,14 +31,14 @@ services:
       DB_HOST: ${@postgres}
     mode: remote
     ports:
-      - '8081:8080'
+      - "8081:8080"
     preRun: yarn db:prepare
     repo:
       name: TouchBistro/venue-core-service
     build:
       args:
         NODE_ENV: development
-        NPM_TOKEN: $NPM_TOKEN
+        NPM_READ_TOKEN: $NPM_READ_TOKEN
       command: yarn start
       dockerfilePath: ${@REPOPATH}
       target: dev

--- a/resource/service/service_test.go
+++ b/resource/service/service_test.go
@@ -328,8 +328,8 @@ func TestComposeConfig(t *testing.T) {
 			},
 			Build: service.Build{
 				Args: map[string]string{
-					"NODE_ENV":  "development",
-					"NPM_TOKEN": "$NPM_TOKEN",
+					"NODE_ENV":       "development",
+					"NPM_READ_TOKEN": "$NPM_READ_TOKEN",
 				},
 				Command:        "yarn start",
 				DockerfilePath: ".tb/repos/TouchBistro/venue-core-service",
@@ -377,8 +377,8 @@ func TestComposeConfig(t *testing.T) {
 			"touchbistro-tb-registry-venue-core-service": {
 				Build: docker.ComposeBuildConfig{
 					Args: map[string]string{
-						"NODE_ENV":  "development",
-						"NPM_TOKEN": "$NPM_TOKEN",
+						"NODE_ENV":       "development",
+						"NPM_READ_TOKEN": "$NPM_READ_TOKEN",
 					},
 					Context: ".tb/repos/TouchBistro/venue-core-service",
 					Target:  "dev",


### PR DESCRIPTION
## 🤷🏻‍♂️ What's the purpose of this PR?

Replacing `NPM_TOKEN` (publish/read permissions) with the new env var `NPM_READ_TOKEN` (read permissions)

## 🖼️ Bigger picture purpose

Current `NPM_TOKEN` has publish permissions and is the only one used. We need a read token for repositories that only need the token for automation & read purposes to establish least privilege principle.

<details>

<summary><h3> 🗒️ Current plan </h3></summary>

1. Merge this PR that adds a new env var `NPM_READ_TOKEN` to be used by repositories that only need read access (backwards compatible)
2. Test that replacing `NPM_TOKEN` with `NPM_READ_TOKEN` in touchbistro-node-boilerplate doesn't break CI builds
  a. https://github.com/TouchBistro/touchbistro-node-boilerplate/pull/1457
3. If this works, replace it for the bigger/critical repositories that only need read access and use the `org-global`CircleCI context
4. If the `org-global` new env var additions and replacing works, do for `org-tbr` and `tb-res-host-app` contexts
5. Replace `NPM_TOKEN` with `NPM_PUBLISH_TOKEN` for repos that publish packages
6. Deprecate `NPM_TOKEN`

</details>