### PR TITLE
fix: Pass preRun as shell script instead of splitting on whitespace

### DIFF
--- a/engine/service.go
+++ b/engine/service.go
@@ -213,6 +213,7 @@ func (e *Engine) Up(ctx context.Context, opts UpOptions) error {
 				}
 
 				tracker.Debugf("Running pre-run for %s", s.FullName())
+				tracker.Debugf("Pre-run command for %s (raw): %q", s.FullName(), s.PreRun)
 				if err := e.dockerClient.RunService(ctx, s.FullName(), s.PreRun); err != nil {
 					return errors.Wrap(err, errors.Meta{
 						Reason: fmt.Sprintf("failed to run pre-run command for %s", s.FullName()),

--- a/integrations/docker/compose.go
+++ b/integrations/docker/compose.go
@@ -74,6 +74,9 @@ func (c *apiClient) ComposeUp(ctx context.Context, project ComposeProject, servi
 }
 
 func (c *apiClient) ComposeRun(ctx context.Context, project ComposeProject, opts ComposeRunOptions) error {
+	tracker := progress.TrackerFromContext(ctx)
+	tracker.Debugf("Compose run requested for service %s with %d args: %q", opts.Service, len(opts.Cmd), opts.Cmd)
+
 	return c.execCompose(ctx, execComposeOptions{
 		project:        project,
 		useComposeFile: true,
@@ -130,9 +133,10 @@ type execComposeOptions struct {
 }
 
 func (c *apiClient) execCompose(ctx context.Context, opts execComposeOptions) error {
+	tracker := progress.TrackerFromContext(ctx)
+
 	var w io.Writer
 	if opts.stdout == nil || opts.stderr == nil {
-		tracker := progress.TrackerFromContext(ctx)
 		op := fmt.Sprintf("docker-compose-%s", opts.args[0])
 		wc := logutil.LogWriter(tracker.WithAttrs("op", op), slog.LevelDebug)
 		defer func() { _ = wc.Close() }()
@@ -154,6 +158,8 @@ func (c *apiClient) execCompose(ctx context.Context, opts execComposeOptions) er
 		args = append(args, "--file", fp)
 	}
 	args = append(args, opts.args...)
+	tracker.Debugf("Executing docker compose command with %d args: %q", len(args), args)
+
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.Stdin = opts.stdin
 	cmd.Stdout = opts.stdout

--- a/integrations/docker/docker.go
+++ b/integrations/docker/docker.go
@@ -513,9 +513,18 @@ func (d *Docker) UpServices(ctx context.Context, serviceNames []string) error {
 
 // RunServices creates a one-off service container and executes a command in it.
 func (d *Docker) RunService(ctx context.Context, serviceName, cmd string) error {
+	tracker := progress.TrackerFromContext(ctx)
+	script := strings.TrimSpace(cmd)
+	shellCmd := []string{"bash", "-c", "set -euo pipefail\n" + script}
+	normalizedServiceName := NormalizeName(serviceName)
+
+	tracker.Debugf("Preparing pre-run compose run for service %s (normalized: %s)", serviceName, normalizedServiceName)
+	tracker.Debugf("Pre-run command for %s (raw): %q", serviceName, cmd)
+	tracker.Debugf("Pre-run command for %s will run via shell with %d args: %q", serviceName, len(shellCmd), shellCmd)
+
 	err := d.apiClient.ComposeRun(ctx, d.project, ComposeRunOptions{
-		Service: NormalizeName(serviceName),
-		Cmd:     strings.Fields(cmd),
+		Service: normalizedServiceName,
+		Cmd:     shellCmd,
 	})
 	if err != nil {
 		return errors.Wrap(err, errors.Meta{


### PR DESCRIPTION
strings.Fields() split multi-line preRun commands into flat tokens, causing only the first command to execute. Wrap the entire script in `bash` and `-euo pipefail` so newlines are preserved as command separators, and any failing command fails the entire script immediately.